### PR TITLE
feat: configurable scheduled sync via GitHub Actions (+1 workflow commit model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ venfork sync develop   # Sync develop branch with upstream/develop
 1. Fetches latest changes from all remotes (upstream, origin, public)
 2. Checks for divergent commits (warns if found to prevent data loss)
 3. Force pushes upstream's default branch to origin and public
-4. If scheduled sync workflow is enabled, re-applies one deterministic top commit for `.github/workflows/sync.yml`
+4. If scheduled sync is enabled, re-applies one deterministic top commit for `.github/workflows/venfork-sync.yml` on the private mirror default branch
 5. **Does not affect your current working branch or feature branches**
 
 **Important:**
@@ -259,6 +259,22 @@ venfork stage bugfix/issue-123
 3. Rebuilds branch history on top of upstream while removing internal workflow commits
 4. Pushes sanitized history to public fork
 5. Provides PR creation link
+
+### `venfork schedule <status|set <cron>|disable>`
+
+Manage automated sync configuration stored in `venfork-config`.
+
+**Examples:**
+```bash
+venfork schedule status
+venfork schedule set "0 */6 * * *"
+venfork schedule disable
+```
+
+**What it does:**
+1. Stores schedule state (`enabled`, `cron`) in `.venfork/config.json` on `venfork-config`
+2. `set` writes/updates `.github/workflows/venfork-sync.yml` on the private mirror default branch
+3. `disable` removes the managed workflow file from that branch
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ venfork sync develop   # Sync develop branch with upstream/develop
 2. Checks for divergent commits (warns if found to prevent data loss)
 3. Pushes upstream's default branch to origin and public
 4. If scheduled sync is enabled, re-applies one deterministic top commit for `.github/workflows/venfork-sync.yml` on the private mirror default branch
-5. If `enabledWorkflows` is configured, that managed commit also removes non-allowlisted workflow files from `.github/workflows`
+5. If workflow policy is configured, that managed commit filters `.github/workflows` using:
+   - `enabledWorkflows` allowlist (highest precedence)
+   - otherwise `disabledWorkflows` blocklist
 6. **Does not affect your current working branch or feature branches**
 
 **Important:**
@@ -277,7 +279,7 @@ venfork schedule disable
 2. `set` writes/updates `.github/workflows/venfork-sync.yml` on the private mirror default branch
 3. `disable` removes the managed workflow file from that branch
 
-### `venfork workflows <status|allow|clear> [workflow-file ...]`
+### `venfork workflows <status|allow|block|clear> [workflow-file ...]`
 
 Manage which upstream workflow files should remain active in the private mirror when managed sync commit logic runs.
 
@@ -285,14 +287,17 @@ Manage which upstream workflow files should remain active in the private mirror 
 ```bash
 venfork workflows status
 venfork workflows allow ci.yml lint.yml
+venfork workflows block deploy.yml e2e.yml
 venfork workflows clear
 ```
 
 **What it does:**
-1. Stores `enabledWorkflows` in `.venfork/config.json` on `venfork-config`
+1. Stores `enabledWorkflows` / `disabledWorkflows` in `.venfork/config.json` on `venfork-config`
 2. `allow` sets the allowlist by workflow filename
-3. `clear` removes the allowlist
-4. Changes apply to the mirror default branch on next `venfork sync` (when schedule is enabled)
+3. `block` sets the blocklist by workflow filename
+4. `clear` removes both lists
+5. Precedence: if `enabledWorkflows` is non-empty, it is used and `disabledWorkflows` is ignored
+6. Changes apply to the mirror default branch on next `venfork sync` (when schedule is enabled)
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,8 @@ venfork sync develop   # Sync develop branch with upstream/develop
 1. Fetches latest changes from all remotes (upstream, origin, public)
 2. Checks for divergent commits (warns if found to prevent data loss)
 3. Force pushes upstream's default branch to origin and public
-4. **Does not affect your current working branch or feature branches**
+4. If scheduled sync workflow is enabled, re-applies one deterministic top commit for `.github/workflows/sync.yml`
+5. **Does not affect your current working branch or feature branches**
 
 **Important:**
 - This keeps your default branches (main/master) in sync with upstream
@@ -255,8 +256,9 @@ venfork stage bugfix/issue-123
 **What it does:**
 1. Verifies branch exists
 2. Shows staging details and confirmation
-3. Pushes to public fork
-4. Provides PR creation link
+3. Rebuilds branch history on top of upstream while removing internal workflow commits
+4. Pushes sanitized history to public fork
+5. Provides PR creation link
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,10 @@ venfork sync develop   # Sync develop branch with upstream/develop
 **What it does:**
 1. Fetches latest changes from all remotes (upstream, origin, public)
 2. Checks for divergent commits (warns if found to prevent data loss)
-3. Force pushes upstream's default branch to origin and public
+3. Pushes upstream's default branch to origin and public
 4. If scheduled sync is enabled, re-applies one deterministic top commit for `.github/workflows/venfork-sync.yml` on the private mirror default branch
-5. **Does not affect your current working branch or feature branches**
+5. If `enabledWorkflows` is configured, that managed commit also removes non-allowlisted workflow files from `.github/workflows`
+6. **Does not affect your current working branch or feature branches**
 
 **Important:**
 - This keeps your default branches (main/master) in sync with upstream
@@ -275,6 +276,23 @@ venfork schedule disable
 1. Stores schedule state (`enabled`, `cron`) in `.venfork/config.json` on `venfork-config`
 2. `set` writes/updates `.github/workflows/venfork-sync.yml` on the private mirror default branch
 3. `disable` removes the managed workflow file from that branch
+
+### `venfork workflows <status|allow|clear> [workflow-file ...]`
+
+Manage which upstream workflow files should remain active in the private mirror when managed sync commit logic runs.
+
+**Examples:**
+```bash
+venfork workflows status
+venfork workflows allow ci.yml lint.yml
+venfork workflows clear
+```
+
+**What it does:**
+1. Stores `enabledWorkflows` in `.venfork/config.json` on `venfork-config`
+2. `allow` sets the allowlist by workflow filename
+3. `clear` removes the allowlist
+4. Changes apply to the mirror default branch on next `venfork sync` (when schedule is enabled)
 
 ## Environment Variables
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,8 @@ async function pathExists(filePath: string): Promise<boolean> {
 const SYNC_WORKFLOW_PATH = getSyncWorkflowPath();
 const WORKFLOW_COMMIT_MESSAGE =
   'chore: add/update scheduled sync workflow (venfork)';
+const VENFORK_BOT_NAME = 'venfork-bot';
+const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
 async function commitSubject(
   ref: string,
@@ -93,28 +95,80 @@ async function isWorkflowCommit(ref: string, cwd?: string): Promise<boolean> {
   return commitTouchesWorkflowPath(ref, cwd);
 }
 
+function isValidCronField(field: string, min: number, max: number): boolean {
+  if (field === '*') {
+    return true;
+  }
+
+  const isValidNumber = (value: string): boolean => {
+    if (!/^\d+$/.test(value)) {
+      return false;
+    }
+    const parsed = Number.parseInt(value, 10);
+    return parsed >= min && parsed <= max;
+  };
+
+  const isValidRange = (value: string): boolean => {
+    const [start, end] = value.split('-');
+    if (!start || !end || !isValidNumber(start) || !isValidNumber(end)) {
+      return false;
+    }
+    return Number.parseInt(start, 10) <= Number.parseInt(end, 10);
+  };
+
+  const stepParts = field.split('/');
+  if (stepParts.length > 2) {
+    return false;
+  }
+  if (stepParts.length === 2) {
+    const [base, step] = stepParts;
+    if (
+      !base ||
+      !step ||
+      !isValidNumber(step) ||
+      Number.parseInt(step, 10) <= 0
+    ) {
+      return false;
+    }
+    if (base === '*') {
+      return true;
+    }
+    if (base.includes(',')) {
+      return false;
+    }
+    return base.includes('-') ? isValidRange(base) : isValidNumber(base);
+  }
+
+  if (field.includes(',')) {
+    return field
+      .split(',')
+      .every((part) =>
+        part.includes('-') ? isValidRange(part) : isValidNumber(part)
+      );
+  }
+  if (field.includes('-')) {
+    return isValidRange(field);
+  }
+  return isValidNumber(field);
+}
+
 function isValidCronExpression(cron: string): boolean {
   const parts = cron.trim().split(/\s+/);
   if (parts.length !== 5) {
     return false;
   }
-  return parts.every((part) => {
-    if (part === '*') {
-      return true;
-    }
-    if (/^\d+$/.test(part)) {
-      return true;
-    }
-    if (/^\*\/\d+$/.test(part)) {
-      return true;
-    }
-    if (/^\d+-\d+$/.test(part)) {
-      return true;
-    }
-    if (/^\d+(,\d+)+$/.test(part)) {
-      return true;
-    }
-    return false;
+
+  const ranges = [
+    { min: 0, max: 59 }, // minute
+    { min: 0, max: 23 }, // hour
+    { min: 1, max: 31 }, // day of month
+    { min: 1, max: 12 }, // month
+    { min: 0, max: 7 }, // day of week
+  ];
+
+  return parts.every((part, index) => {
+    const range = ranges[index];
+    return isValidCronField(part, range.min, range.max);
   });
 }
 
@@ -122,6 +176,16 @@ async function isScheduleEnabled(cwd?: string): Promise<boolean> {
   const repoDir = cwd ?? process.cwd();
   const config = await readVenforkConfigFromRepo(repoDir);
   return Boolean(config?.schedule?.enabled);
+}
+
+async function remoteBranchExists(
+  remote: string,
+  branch: string
+): Promise<boolean> {
+  const result = await $({
+    reject: false,
+  })`git ls-remote --exit-code --heads ${remote} ${branch}`;
+  return result.exitCode === 0;
 }
 
 async function applyScheduledWorkflowCommit(
@@ -148,7 +212,7 @@ async function applyScheduledWorkflowCommit(
     await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
     await $({
       cwd: tempDir,
-    })`git commit --allow-empty -m ${WORKFLOW_COMMIT_MESSAGE}`;
+    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit --allow-empty -m ${WORKFLOW_COMMIT_MESSAGE}`;
 
     await $({
       cwd: tempDir,
@@ -198,7 +262,7 @@ async function updateWorkflowOnOriginDefault(
 
     await $({
       cwd: tempDir,
-    })`git commit -m ${WORKFLOW_COMMIT_MESSAGE}`;
+    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit -m ${WORKFLOW_COMMIT_MESSAGE}`;
     await $({
       cwd: tempDir,
     })`git push origin HEAD:${defaultBranch} --force`;
@@ -852,7 +916,8 @@ export async function syncCommand(
         let userFacingDivergence = 0;
         for (const commit of divergentCommits) {
           if (!(await isWorkflowCommit(commit, options?.cwd))) {
-            userFacingDivergence += 1;
+            userFacingDivergence = 1;
+            break;
           }
         }
         return userFacingDivergence;
@@ -1137,7 +1202,11 @@ This makes your work visible and ready for PR to upstream.
       s.stop('Prepared sanitized branch');
 
       s.start('Pushing sanitized branch to public fork');
-      await $`git push public ${stageHead}:refs/heads/${branch} --force`;
+      if (await remoteBranchExists('public', branch)) {
+        await $`git push public ${stageHead}:refs/heads/${branch} --force-with-lease=refs/heads/${branch}`;
+      } else {
+        await $`git push public ${stageHead}:refs/heads/${branch}`;
+      }
       s.stop('Push successful');
     } else {
       s.start('Pushing to public fork');

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,7 +4,12 @@ import os from 'node:os';
 import path from 'node:path';
 import * as p from '@clack/prompts';
 import { $ } from 'execa';
-import { createConfigBranch, fetchVenforkConfig } from './config.js';
+import {
+  createConfigBranch,
+  fetchVenforkConfig,
+  readVenforkConfigFromRepo,
+  updateVenforkConfig,
+} from './config.js';
 import {
   AuthenticationError,
   BranchNotFoundError,
@@ -27,6 +32,7 @@ import {
   parseRepoName,
   parseRepoPath,
 } from './utils.js';
+import { generateSyncWorkflow, getSyncWorkflowPath } from './workflow.js';
 
 async function pathExists(filePath: string): Promise<boolean> {
   try {
@@ -37,31 +43,9 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
-const SYNC_WORKFLOW_PATH = '.github/workflows/sync.yml';
+const SYNC_WORKFLOW_PATH = getSyncWorkflowPath();
 const WORKFLOW_COMMIT_MESSAGE =
   'chore: add/update scheduled sync workflow (venfork)';
-
-// Keep this workflow body deterministic so the "+1 commit" is stable and easy to detect.
-const SYNC_WORKFLOW_CONTENT = `name: Venfork Sync
-on:
-  schedule:
-    - cron: '0 * * * *'
-  workflow_dispatch:
-
-permissions:
-  contents: write
-
-jobs:
-  sync:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout mirror
-        uses: actions/checkout@v4
-      - name: Install venfork
-        run: npm install -g venfork
-      - name: Sync from upstream
-        run: venfork sync
-`;
 
 async function commitSubject(
   ref: string,
@@ -109,42 +93,48 @@ async function isWorkflowCommit(ref: string, cwd?: string): Promise<boolean> {
   return commitTouchesWorkflowPath(ref, cwd);
 }
 
-async function hasWorkflowAtRef(ref: string, cwd?: string): Promise<boolean> {
-  const cwdOpt = cwd ? { cwd } : {};
-  const result = await $({
-    ...cwdOpt,
-    reject: false,
-  })`git show ${ref}:${SYNC_WORKFLOW_PATH}`;
-  return result.exitCode === 0;
-}
-
-async function shouldKeepScheduledWorkflowCommit(
-  defaultBranch: string,
-  cwd?: string
-): Promise<boolean> {
-  // Preserve scheduling whenever any synced default branch currently carries
-  // the internal workflow marker (message or workflow file presence).
-  const refs = [`origin/${defaultBranch}`, `public/${defaultBranch}`];
-
-  for (const ref of refs) {
-    if (
-      (await isWorkflowCommit(ref, cwd)) ||
-      (await hasWorkflowAtRef(ref, cwd))
-    ) {
+function isValidCronExpression(cron: string): boolean {
+  const parts = cron.trim().split(/\s+/);
+  if (parts.length !== 5) {
+    return false;
+  }
+  return parts.every((part) => {
+    if (part === '*') {
       return true;
     }
-  }
-  return false;
+    if (/^\d+$/.test(part)) {
+      return true;
+    }
+    if (/^\*\/\d+$/.test(part)) {
+      return true;
+    }
+    if (/^\d+-\d+$/.test(part)) {
+      return true;
+    }
+    if (/^\d+(,\d+)+$/.test(part)) {
+      return true;
+    }
+    return false;
+  });
+}
+
+async function isScheduleEnabled(cwd?: string): Promise<boolean> {
+  const repoDir = cwd ?? process.cwd();
+  const config = await readVenforkConfigFromRepo(repoDir);
+  return Boolean(config?.schedule?.enabled);
 }
 
 async function applyScheduledWorkflowCommit(
   defaultBranch: string,
+  cron: string,
   cwd?: string
 ): Promise<void> {
   const repoDir = cwd ?? process.cwd();
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-sync-'));
 
   try {
+    // Re-stamp from upstream so the private mirror default branch is always
+    // `upstream + exactly one deterministic internal workflow commit`.
     await $({
       cwd: repoDir,
     })`git worktree add --detach ${tempDir} upstream/${defaultBranch}`;
@@ -153,7 +143,7 @@ async function applyScheduledWorkflowCommit(
     });
     await writeFile(
       path.join(tempDir, SYNC_WORKFLOW_PATH),
-      SYNC_WORKFLOW_CONTENT
+      generateSyncWorkflow(cron)
     );
     await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
     await $({
@@ -163,9 +153,6 @@ async function applyScheduledWorkflowCommit(
     await $({
       cwd: tempDir,
     })`git push origin HEAD:${defaultBranch} --force`;
-    await $({
-      cwd: tempDir,
-    })`git push public HEAD:${defaultBranch} --force`;
   } finally {
     await $({
       cwd: repoDir,
@@ -175,42 +162,87 @@ async function applyScheduledWorkflowCommit(
   }
 }
 
-async function buildPublicStageHeadWithoutWorkflowCommits(
-  branch: string,
-  upstreamDefaultBranch: string
-): Promise<string> {
-  const revListResult =
-    await $`git rev-list --reverse upstream/${upstreamDefaultBranch}..${branch}`;
-  const candidateCommits = revListResult.stdout
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean);
+async function updateWorkflowOnOriginDefault(
+  defaultBranch: string,
+  workflowContent: string | null,
+  cwd?: string
+): Promise<boolean> {
+  const repoDir = cwd ?? process.cwd();
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-workflow-'));
 
-  const commitsToApply: string[] = [];
-  for (const commit of candidateCommits) {
-    if (!(await isWorkflowCommit(commit))) {
-      commitsToApply.push(commit);
-    }
-  }
-
-  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-stage-'));
   try {
-    await $`git worktree add --detach ${tempDir} upstream/${upstreamDefaultBranch}`;
-    for (const commit of commitsToApply) {
-      const cherryPick = await $({
+    await $({
+      cwd: repoDir,
+    })`git worktree add --detach ${tempDir} origin/${defaultBranch}`;
+
+    if (workflowContent === null) {
+      await $({
         cwd: tempDir,
         reject: false,
-      })`git cherry-pick ${commit}`;
-      if (cherryPick.exitCode !== 0) {
-        throw new Error(
-          `Failed to stage '${branch}' cleanly while removing internal workflow commits. Rebase '${branch}' on upstream/${upstreamDefaultBranch} and retry.`
-        );
-      }
+      })`git rm --quiet --ignore-unmatch ${SYNC_WORKFLOW_PATH}`;
+    } else {
+      await mkdir(path.join(tempDir, '.github', 'workflows'), {
+        recursive: true,
+      });
+      await writeFile(path.join(tempDir, SYNC_WORKFLOW_PATH), workflowContent);
+      await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
+    }
+
+    const stagedDiff = await $({
+      cwd: tempDir,
+      reject: false,
+    })`git diff --cached --quiet`;
+    if (stagedDiff.exitCode === 0) {
+      return false;
+    }
+
+    await $({
+      cwd: tempDir,
+    })`git commit -m ${WORKFLOW_COMMIT_MESSAGE}`;
+    await $({
+      cwd: tempDir,
+    })`git push origin HEAD:${defaultBranch} --force`;
+    return true;
+  } finally {
+    await $({
+      cwd: repoDir,
+      reject: false,
+    })`git worktree remove --force ${tempDir}`;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function buildPublicStageHeadWithoutWorkflowCommit(
+  branch: string,
+  defaultBranch: string,
+  cwd?: string
+): Promise<string> {
+  const repoDir = cwd ?? process.cwd();
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-stage-'));
+  try {
+    await $({
+      cwd: repoDir,
+    })`git worktree add --detach ${tempDir} ${branch}`;
+    const rebaseResult = await $({
+      cwd: tempDir,
+      reject: false,
+    })`git rebase --onto upstream/${defaultBranch} origin/${defaultBranch}`;
+    if (rebaseResult.exitCode !== 0) {
+      await $({
+        cwd: tempDir,
+        reject: false,
+      })`git rebase --abort`;
+      throw new Error(
+        `Failed to stage '${branch}' because removing the internal workflow commit caused rebase conflicts. Rebase '${branch}' on upstream/${defaultBranch} and retry.`
+      );
     }
     const headResult = await $({ cwd: tempDir })`git rev-parse HEAD`;
     return headResult.stdout.trim();
   } finally {
-    await $({ reject: false })`git worktree remove --force ${tempDir}`;
+    await $({
+      cwd: repoDir,
+      reject: false,
+    })`git worktree remove --force ${tempDir}`;
     await rm(tempDir, { recursive: true, force: true });
   }
 }
@@ -800,10 +832,9 @@ export async function syncCommand(
     // Step 2: Detect default branch if not specified
     const defaultBranch =
       targetBranch || (await getDefaultBranch('upstream', options?.cwd));
-    const keepWorkflowCommit = await shouldKeepScheduledWorkflowCommit(
-      defaultBranch,
-      options?.cwd
-    );
+    const repoDir = options?.cwd ?? process.cwd();
+    const config = await readVenforkConfigFromRepo(repoDir);
+    const scheduleConfig = config?.schedule;
 
     // Step 3: Check for divergence
     s.start('Checking for divergent commits');
@@ -881,11 +912,15 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
     s.stop('Synced to all remotes');
 
     // Step 6: Enforce mirror "+1 commit" model for scheduled sync workflow.
-    // If scheduling is enabled, we always normalize to exactly one deterministic
-    // top commit that manages .github/workflows/sync.yml.
-    if (keepWorkflowCommit) {
+    // Scheduling config lives on `venfork-config`; when enabled we re-stamp
+    // one deterministic workflow commit on top of upstream.
+    if (scheduleConfig?.enabled && scheduleConfig.cron) {
       s.start('Re-applying scheduled sync workflow commit');
-      await applyScheduledWorkflowCommit(defaultBranch, options?.cwd);
+      await applyScheduledWorkflowCommit(
+        defaultBranch,
+        scheduleConfig.cron,
+        options?.cwd
+      );
       s.stop('Scheduled workflow commit normalized');
     }
 
@@ -900,6 +935,110 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
     if (!quiet) {
       p.outro('❌ Sync failed');
     }
+    process.exit(1);
+  }
+}
+
+/**
+ * Schedule command: Configure automated sync via GitHub Actions workflow.
+ */
+export async function scheduleCommand(
+  action?: string,
+  value?: string
+): Promise<void> {
+  p.intro('⏰ Venfork Schedule');
+  const repoDir = process.cwd();
+  const s = p.spinner();
+
+  try {
+    const defaultBranch = await getDefaultBranch('upstream');
+
+    if (action === 'set') {
+      const cron = value?.trim();
+      if (!cron) {
+        p.log.error('Cron expression is required');
+        p.outro('Usage: venfork schedule set "<cron>"');
+        process.exit(1);
+      }
+      if (!isValidCronExpression(cron)) {
+        p.log.error('Invalid cron expression (expected 5 fields)');
+        p.outro('Usage: venfork schedule set "<cron>"');
+        process.exit(1);
+      }
+
+      s.start('Updating schedule in venfork-config');
+      await updateVenforkConfig(repoDir, {
+        schedule: { enabled: true, cron },
+      });
+      s.stop('Schedule configuration updated');
+
+      await $`git fetch origin`;
+      s.start('Updating workflow on default branch');
+      await updateWorkflowOnOriginDefault(
+        defaultBranch,
+        generateSyncWorkflow(cron),
+        repoDir
+      );
+      s.stop('Workflow updated');
+
+      p.outro(
+        `✨ Scheduled sync enabled\n\nBranch: ${defaultBranch}\nCron: ${cron}\nWorkflow: ${SYNC_WORKFLOW_PATH}`
+      );
+      return;
+    }
+
+    if (action === 'disable') {
+      s.start('Disabling schedule in venfork-config');
+      const currentConfig = await readVenforkConfigFromRepo(repoDir);
+      if (!currentConfig) {
+        throw new Error('venfork-config branch not found or invalid');
+      }
+      await updateVenforkConfig(repoDir, {
+        schedule: {
+          enabled: false,
+          cron: currentConfig.schedule?.cron || '0 * * * *',
+        },
+      });
+      s.stop('Schedule configuration updated');
+
+      await $`git fetch origin`;
+      s.start('Removing workflow from default branch');
+      await updateWorkflowOnOriginDefault(defaultBranch, null, repoDir);
+      s.stop('Workflow removed');
+
+      p.outro(
+        `✨ Scheduled sync disabled\n\nBranch: ${defaultBranch}\nWorkflow removed: ${SYNC_WORKFLOW_PATH}`
+      );
+      return;
+    }
+
+    if (action === 'status' || !action) {
+      s.start('Reading schedule configuration');
+      const config = await readVenforkConfigFromRepo(repoDir);
+      s.stop('Configuration loaded');
+      if (!config) {
+        throw new Error('venfork-config branch not found or invalid');
+      }
+      const schedule = config.schedule;
+      const enabled = Boolean(schedule?.enabled);
+      const cron = schedule?.cron || '(not set)';
+      p.note(
+        `Branch: ${defaultBranch}\nEnabled: ${enabled ? 'yes' : 'no'}\nCron: ${cron}\nWorkflow: ${SYNC_WORKFLOW_PATH}`,
+        'Schedule Status'
+      );
+      p.outro('✨ Schedule status shown');
+      return;
+    }
+
+    p.log.error(`Unknown schedule action: ${action}`);
+    p.outro(
+      'Usage: venfork schedule <status|set <cron>|disable>\nExample: venfork schedule set "0 */6 * * *"'
+    );
+    process.exit(1);
+  } catch (error) {
+    s.stop('Error occurred');
+    p.log.error(error instanceof Error ? error.message : String(error));
+    p.outro('❌ Schedule command failed');
     process.exit(1);
   }
 }
@@ -978,24 +1117,35 @@ This makes your work visible and ready for PR to upstream.
       process.exit(0);
     }
 
+    const repoDir = process.cwd();
+
     // Step 5: Detect upstream default branch for staging + PR URL
     const upstreamDefaultBranch = await getDefaultBranch('upstream');
+    const scheduleEnabled = await isScheduleEnabled(repoDir);
 
-    // Step 6: Build a sanitized public branch history that excludes internal
-    // workflow commits from PRs (upstream should only see real user changes).
-    s.start('Preparing sanitized branch for public staging');
-    const stageHead = await buildPublicStageHeadWithoutWorkflowCommits(
-      branch,
-      upstreamDefaultBranch
-    );
-    s.stop('Prepared sanitized branch');
+    // Step 6: If schedule is enabled, strip the internal workflow commit before
+    // publishing. Otherwise keep normal direct branch push behavior.
+    if (scheduleEnabled) {
+      await $`git fetch upstream`;
+      await $`git fetch origin`;
+      s.start('Preparing sanitized branch for public staging');
+      const stageHead = await buildPublicStageHeadWithoutWorkflowCommit(
+        branch,
+        upstreamDefaultBranch,
+        repoDir
+      );
+      s.stop('Prepared sanitized branch');
 
-    // Step 7: Push sanitized ref to public fork
-    s.start('Pushing to public fork');
-    await $`git push public ${stageHead}:refs/heads/${branch} --force`;
-    s.stop('Push successful');
+      s.start('Pushing sanitized branch to public fork');
+      await $`git push public ${stageHead}:refs/heads/${branch} --force`;
+      s.stop('Push successful');
+    } else {
+      s.start('Pushing to public fork');
+      await $`git push public ${branch}`;
+      s.stop('Push successful');
+    }
 
-    // Step 8: Show PR creation link
+    // Step 7: Show PR creation link
     const prUrl = `https://github.com/${upstreamRepoPath}/compare/${upstreamDefaultBranch}...${publicRepoPath.split('/')[0]}:${branch}?expand=1`;
 
     p.note(
@@ -1116,12 +1266,16 @@ venfork status
 
 venfork sync [branch]
   Update default branches of origin and public to match upstream
-  Keeps an internal deterministic +1 workflow commit when scheduling is enabled
+  Re-stamps private default branch as upstream + one internal workflow commit when schedule is enabled
   Syncs main/master branch without affecting your current work
+
+venfork schedule <status|set <cron>|disable>
+  Manage scheduled sync config stored in venfork-config
+  Set writes/removes ${SYNC_WORKFLOW_PATH} on the private mirror default branch
 
 venfork stage <branch>
   Push branch to public fork for PR to upstream
-  Strips internal workflow commits so PR history contains only upstream + user changes
+  When schedule is enabled, strips internal workflow commit before public push
   This is when your work becomes visible to the client`,
     'Available Commands'
   );

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1014,7 +1014,7 @@ This suggests commits were made directly to the default branch.
 Force syncing will LOSE these commits.
 
 To preserve them: manually rebase or cherry-pick before running sync.
-To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch} -f`,
+To force sync anyway: git push origin upstream/${defaultBranch}:refs/heads/${defaultBranch} -f`,
         '⚠️  Warning'
       );
 
@@ -1029,10 +1029,10 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
 
     await $(
       cwdOpt
-    )`git push origin upstream/${defaultBranch}:${defaultBranch} --force-with-lease`;
+    )`git push origin upstream/${defaultBranch}:refs/heads/${defaultBranch} --force-with-lease`;
     await $(
       cwdOpt
-    )`git push public upstream/${defaultBranch}:${defaultBranch} --force-with-lease`;
+    )`git push public upstream/${defaultBranch}:refs/heads/${defaultBranch} --force-with-lease`;
 
     s.stop('Synced to all remotes');
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import * as p from '@clack/prompts';

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -76,16 +76,22 @@ async function commitTouchesWorkflowPath(
   if (filesResult.exitCode !== 0) {
     return false;
   }
-  return filesResult.stdout.split('\n').some((line) => {
-    return line.trim() === SYNC_WORKFLOW_PATH;
-  });
+  const files = filesResult.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (files.length === 0) {
+    return false;
+  }
+  // Only treat as a workflow-only commit when every changed path is the managed workflow path.
+  return files.every((filePath) => filePath === SYNC_WORKFLOW_PATH);
 }
 
 /**
  * Internal workflow commit marker used by the mirror "+1 commit" model.
  *
  * We identify this commit by its deterministic message and also accept commits
- * that touch the managed workflow file, so historical repos can still be normalized.
+ * that change only the managed workflow file, so historical repos can still be normalized.
  */
 async function isWorkflowCommit(ref: string, cwd?: string): Promise<boolean> {
   const subject = await commitSubject(ref, cwd);
@@ -216,7 +222,7 @@ async function applyScheduledWorkflowCommit(
 
     await $({
       cwd: tempDir,
-    })`git push origin HEAD:${defaultBranch} --force`;
+    })`git push origin HEAD:${defaultBranch} --force-with-lease`;
   } finally {
     await $({
       cwd: repoDir,
@@ -265,7 +271,7 @@ async function updateWorkflowOnOriginDefault(
     })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit -m ${WORKFLOW_COMMIT_MESSAGE}`;
     await $({
       cwd: tempDir,
-    })`git push origin HEAD:${defaultBranch} --force`;
+    })`git push origin HEAD:${defaultBranch} --force-with-lease`;
     return true;
   } finally {
     await $({
@@ -916,8 +922,7 @@ export async function syncCommand(
         let userFacingDivergence = 0;
         for (const commit of divergentCommits) {
           if (!(await isWorkflowCommit(commit, options?.cwd))) {
-            userFacingDivergence = 1;
-            break;
+            userFacingDivergence += 1;
           }
         }
         return userFacingDivergence;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -50,7 +50,7 @@ const WORKFLOWS_DIR = '.github/workflows';
 const VENFORK_BOT_NAME = 'venfork-bot';
 const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
-function normalizeWorkflowAllowlist(entries: string[]): string[] {
+function normalizeWorkflowList(entries: string[]): string[] {
   return Array.from(
     new Set(
       entries
@@ -224,11 +224,13 @@ async function applyScheduledWorkflowCommit(
   defaultBranch: string,
   cron: string,
   enabledWorkflows: string[],
+  disabledWorkflows: string[],
   cwd?: string
 ): Promise<void> {
   const repoDir = cwd ?? process.cwd();
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-sync-'));
-  const allowlist = normalizeWorkflowAllowlist(enabledWorkflows);
+  const allowlist = normalizeWorkflowList(enabledWorkflows);
+  const blocklist = normalizeWorkflowList(disabledWorkflows);
 
   try {
     // Re-stamp from upstream so the private mirror default branch is always
@@ -245,16 +247,20 @@ async function applyScheduledWorkflowCommit(
     );
     await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
 
-    // If a workflow allowlist is configured, keep only allowed upstream
-    // workflow files plus the venfork-managed sync workflow.
-    if (allowlist.length > 0) {
+    // Filter upstream workflow files as part of the managed "+1" commit.
+    // Precedence: enabledWorkflows allowlist > disabledWorkflows blocklist.
+    if (allowlist.length > 0 || blocklist.length > 0) {
       const workflowFiles = await listWorkflowFiles(tempDir);
       for (const workflowFile of workflowFiles) {
         if (workflowFile === SYNC_WORKFLOW_PATH) {
           continue;
         }
         const base = path.basename(workflowFile);
-        if (!allowlist.includes(base)) {
+        const shouldKeep =
+          allowlist.length > 0
+            ? allowlist.includes(base)
+            : !blocklist.includes(base);
+        if (!shouldKeep) {
           await $({
             cwd: tempDir,
             reject: false,
@@ -953,6 +959,7 @@ export async function syncCommand(
     const config = await readVenforkConfigFromRepo(repoDir);
     const scheduleConfig = config?.schedule;
     const enabledWorkflows = config?.enabledWorkflows ?? [];
+    const disabledWorkflows = config?.disabledWorkflows ?? [];
 
     // Step 3: Check for divergence
     s.start('Checking for divergent commits');
@@ -1038,6 +1045,7 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
         defaultBranch,
         scheduleConfig.cron,
         enabledWorkflows,
+        disabledWorkflows,
         options?.cwd
       );
       s.stop('Scheduled workflow commit normalized');
@@ -1166,7 +1174,7 @@ export async function scheduleCommand(
  * Workflows command: manage workflow allowlist in venfork-config.
  */
 export async function workflowsCommand(
-  action: 'status' | 'allow' | 'clear',
+  action: 'status' | 'allow' | 'block' | 'clear',
   workflows: string[]
 ): Promise<void> {
   p.intro('🧩 Venfork Workflows');
@@ -1179,37 +1187,63 @@ export async function workflowsCommand(
         throw new Error('venfork-config branch not found or invalid');
       }
       const allowlist = config.enabledWorkflows ?? [];
-      if (allowlist.length === 0) {
+      const blocklist = config.disabledWorkflows ?? [];
+      if (allowlist.length === 0 && blocklist.length === 0) {
         p.note(
-          'No workflow allowlist configured. Mirror keeps all upstream workflows unless schedule logic modifies them.',
+          'No workflow policy configured. Mirror keeps all upstream workflows unless schedule logic modifies them.',
           'Workflows Status'
         );
       } else {
-        p.note(
-          allowlist.map((name) => `- ${name}`).join('\n'),
-          'Allowed workflow files'
-        );
+        const lines = [
+          `enabledWorkflows: ${allowlist.length > 0 ? 'set' : 'not set'}`,
+          `disabledWorkflows: ${blocklist.length > 0 ? 'set' : 'not set'}`,
+          allowlist.length > 0
+            ? `Allowed files:\n${allowlist.map((name) => `- ${name}`).join('\n')}`
+            : '',
+          blocklist.length > 0
+            ? `Blocked files:\n${blocklist.map((name) => `- ${name}`).join('\n')}`
+            : '',
+          allowlist.length > 0
+            ? 'Precedence: enabledWorkflows allowlist overrides disabledWorkflows.'
+            : '',
+        ].filter((line) => line.length > 0);
+        p.note(lines.join('\n'), 'Workflow Policy');
       }
       p.outro('✨ Workflows status shown');
       return;
     }
 
     if (action === 'clear') {
-      await updateVenforkConfig(repoDir, { enabledWorkflows: null });
+      await updateVenforkConfig(repoDir, {
+        enabledWorkflows: null,
+        disabledWorkflows: null,
+      });
       p.outro(
-        '✨ Workflow allowlist cleared. Run `venfork sync` to apply on the private mirror default branch.'
+        '✨ Workflow policy cleared. Run `venfork sync` to apply on the private mirror default branch.'
       );
       return;
     }
 
-    const normalized = normalizeWorkflowAllowlist(workflows);
-    await updateVenforkConfig(repoDir, { enabledWorkflows: normalized });
+    const normalized = normalizeWorkflowList(workflows);
+    if (action === 'allow') {
+      await updateVenforkConfig(repoDir, { enabledWorkflows: normalized });
+      p.note(
+        normalized.map((name) => `- ${name}`).join('\n'),
+        'Allowed workflow files'
+      );
+      p.outro(
+        '✨ Workflow allowlist updated. Run `venfork sync` to apply on the private mirror default branch.'
+      );
+      return;
+    }
+
+    await updateVenforkConfig(repoDir, { disabledWorkflows: normalized });
     p.note(
       normalized.map((name) => `- ${name}`).join('\n'),
-      'Allowed workflow files'
+      'Blocked workflow files'
     );
     p.outro(
-      '✨ Workflow allowlist updated. Run `venfork sync` to apply on the private mirror default branch.'
+      '✨ Workflow blocklist updated. Run `venfork sync` to apply on the private mirror default branch.'
     );
   } catch (error) {
     p.log.error(error instanceof Error ? error.message : String(error));
@@ -1446,7 +1480,7 @@ venfork status
 venfork sync [branch]
   Update default branches of origin and public to match upstream
   Re-stamps private default branch as upstream + one internal workflow commit when schedule is enabled
-  Applies workflow allowlist filtering when enabledWorkflows is configured
+  Applies workflow filtering from enabledWorkflows/disabledWorkflows policy
   Syncs main/master branch without affecting your current work
 
 venfork schedule <status|set <cron>|disable>
@@ -1458,8 +1492,8 @@ venfork stage <branch>
   When schedule is enabled, strips internal workflow commit before public push
   This is when your work becomes visible to the client
 
-venfork workflows <status|allow|clear> [workflow-file ...]
-  Configure enabledWorkflows allowlist for mirror workflows in venfork-config`,
+venfork workflows <status|allow|block|clear> [workflow-file ...]
+  Configure workflow allowlist/blocklist policy in venfork-config`,
     'Available Commands'
   );
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { access, rm } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import * as p from '@clack/prompts';
@@ -34,6 +34,184 @@ async function pathExists(filePath: string): Promise<boolean> {
     return true;
   } catch {
     return false;
+  }
+}
+
+const SYNC_WORKFLOW_PATH = '.github/workflows/sync.yml';
+const WORKFLOW_COMMIT_MESSAGE =
+  'chore: add/update scheduled sync workflow (venfork)';
+
+// Keep this workflow body deterministic so the "+1 commit" is stable and easy to detect.
+const SYNC_WORKFLOW_CONTENT = `name: Venfork Sync
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mirror
+        uses: actions/checkout@v4
+      - name: Install venfork
+        run: npm install -g venfork
+      - name: Sync from upstream
+        run: venfork sync
+`;
+
+async function commitSubject(
+  ref: string,
+  cwd?: string
+): Promise<string | null> {
+  const cwdOpt = cwd ? { cwd } : {};
+  const result = await $({
+    ...cwdOpt,
+    reject: false,
+  })`git log -1 --format=%s ${ref}`;
+  if (result.exitCode !== 0) {
+    return null;
+  }
+  return result.stdout.trim();
+}
+
+async function commitTouchesWorkflowPath(
+  ref: string,
+  cwd?: string
+): Promise<boolean> {
+  const cwdOpt = cwd ? { cwd } : {};
+  const filesResult = await $({
+    ...cwdOpt,
+    reject: false,
+  })`git show --name-only --pretty=format: ${ref}`;
+  if (filesResult.exitCode !== 0) {
+    return false;
+  }
+  return filesResult.stdout.split('\n').some((line) => {
+    return line.trim() === SYNC_WORKFLOW_PATH;
+  });
+}
+
+/**
+ * Internal workflow commit marker used by the mirror "+1 commit" model.
+ *
+ * We identify this commit by its deterministic message and also accept commits
+ * that touch the managed workflow file, so historical repos can still be normalized.
+ */
+async function isWorkflowCommit(ref: string, cwd?: string): Promise<boolean> {
+  const subject = await commitSubject(ref, cwd);
+  if (subject === WORKFLOW_COMMIT_MESSAGE) {
+    return true;
+  }
+  return commitTouchesWorkflowPath(ref, cwd);
+}
+
+async function hasWorkflowAtRef(ref: string, cwd?: string): Promise<boolean> {
+  const cwdOpt = cwd ? { cwd } : {};
+  const result = await $({
+    ...cwdOpt,
+    reject: false,
+  })`git show ${ref}:${SYNC_WORKFLOW_PATH}`;
+  return result.exitCode === 0;
+}
+
+async function shouldKeepScheduledWorkflowCommit(
+  defaultBranch: string,
+  cwd?: string
+): Promise<boolean> {
+  // Preserve scheduling whenever any synced default branch currently carries
+  // the internal workflow marker (message or workflow file presence).
+  const refs = [`origin/${defaultBranch}`, `public/${defaultBranch}`];
+
+  for (const ref of refs) {
+    if (
+      (await isWorkflowCommit(ref, cwd)) ||
+      (await hasWorkflowAtRef(ref, cwd))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function applyScheduledWorkflowCommit(
+  defaultBranch: string,
+  cwd?: string
+): Promise<void> {
+  const repoDir = cwd ?? process.cwd();
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-sync-'));
+
+  try {
+    await $({
+      cwd: repoDir,
+    })`git worktree add --detach ${tempDir} upstream/${defaultBranch}`;
+    await mkdir(path.join(tempDir, '.github', 'workflows'), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(tempDir, SYNC_WORKFLOW_PATH),
+      SYNC_WORKFLOW_CONTENT
+    );
+    await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
+    await $({
+      cwd: tempDir,
+    })`git commit --allow-empty -m ${WORKFLOW_COMMIT_MESSAGE}`;
+
+    await $({
+      cwd: tempDir,
+    })`git push origin HEAD:${defaultBranch} --force`;
+    await $({
+      cwd: tempDir,
+    })`git push public HEAD:${defaultBranch} --force`;
+  } finally {
+    await $({
+      cwd: repoDir,
+      reject: false,
+    })`git worktree remove --force ${tempDir}`;
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+async function buildPublicStageHeadWithoutWorkflowCommits(
+  branch: string,
+  upstreamDefaultBranch: string
+): Promise<string> {
+  const revListResult =
+    await $`git rev-list --reverse upstream/${upstreamDefaultBranch}..${branch}`;
+  const candidateCommits = revListResult.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  const commitsToApply: string[] = [];
+  for (const commit of candidateCommits) {
+    if (!(await isWorkflowCommit(commit))) {
+      commitsToApply.push(commit);
+    }
+  }
+
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-stage-'));
+  try {
+    await $`git worktree add --detach ${tempDir} upstream/${upstreamDefaultBranch}`;
+    for (const commit of commitsToApply) {
+      const cherryPick = await $({
+        cwd: tempDir,
+        reject: false,
+      })`git cherry-pick ${commit}`;
+      if (cherryPick.exitCode !== 0) {
+        throw new Error(
+          `Failed to stage '${branch}' cleanly while removing internal workflow commits. Rebase '${branch}' on upstream/${upstreamDefaultBranch} and retry.`
+        );
+      }
+    }
+    const headResult = await $({ cwd: tempDir })`git rev-parse HEAD`;
+    return headResult.stdout.trim();
+  } finally {
+    await $({ reject: false })`git worktree remove --force ${tempDir}`;
+    await rm(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -622,6 +800,10 @@ export async function syncCommand(
     // Step 2: Detect default branch if not specified
     const defaultBranch =
       targetBranch || (await getDefaultBranch('upstream', options?.cwd));
+    const keepWorkflowCommit = await shouldKeepScheduledWorkflowCommit(
+      defaultBranch,
+      options?.cwd
+    );
 
     // Step 3: Check for divergence
     s.start('Checking for divergent commits');
@@ -630,8 +812,19 @@ export async function syncCommand(
       try {
         const result = await $({
           ...cwdOpt,
-        })`git rev-list --count upstream/${defaultBranch}..${remote}/${defaultBranch}`;
-        return Number.parseInt(result.stdout.trim(), 10);
+        })`git rev-list upstream/${defaultBranch}..${remote}/${defaultBranch}`;
+        const divergentCommits = result.stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+
+        let userFacingDivergence = 0;
+        for (const commit of divergentCommits) {
+          if (!(await isWorkflowCommit(commit, options?.cwd))) {
+            userFacingDivergence += 1;
+          }
+        }
+        return userFacingDivergence;
       } catch {
         // Remote branch might not exist yet (first sync)
         return 0;
@@ -686,6 +879,15 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
     )`git push public upstream/${defaultBranch}:${defaultBranch} --force`;
 
     s.stop('Synced to all remotes');
+
+    // Step 6: Enforce mirror "+1 commit" model for scheduled sync workflow.
+    // If scheduling is enabled, we always normalize to exactly one deterministic
+    // top commit that manages .github/workflows/sync.yml.
+    if (keepWorkflowCommit) {
+      s.start('Re-applying scheduled sync workflow commit');
+      await applyScheduledWorkflowCommit(defaultBranch, options?.cwd);
+      s.stop('Scheduled workflow commit normalized');
+    }
 
     if (!quiet) {
       p.outro(
@@ -776,15 +978,24 @@ This makes your work visible and ready for PR to upstream.
       process.exit(0);
     }
 
-    // Step 5: Push to public fork
-    s.start('Pushing to public fork');
-    await $`git push public ${branch}`;
-    s.stop('Push successful');
-
-    // Step 6: Detect upstream default branch for PR URL
+    // Step 5: Detect upstream default branch for staging + PR URL
     const upstreamDefaultBranch = await getDefaultBranch('upstream');
 
-    // Step 7: Show PR creation link
+    // Step 6: Build a sanitized public branch history that excludes internal
+    // workflow commits from PRs (upstream should only see real user changes).
+    s.start('Preparing sanitized branch for public staging');
+    const stageHead = await buildPublicStageHeadWithoutWorkflowCommits(
+      branch,
+      upstreamDefaultBranch
+    );
+    s.stop('Prepared sanitized branch');
+
+    // Step 7: Push sanitized ref to public fork
+    s.start('Pushing to public fork');
+    await $`git push public ${stageHead}:refs/heads/${branch} --force`;
+    s.stop('Push successful');
+
+    // Step 8: Show PR creation link
     const prUrl = `https://github.com/${upstreamRepoPath}/compare/${upstreamDefaultBranch}...${publicRepoPath.split('/')[0]}:${branch}?expand=1`;
 
     p.note(
@@ -905,10 +1116,12 @@ venfork status
 
 venfork sync [branch]
   Update default branches of origin and public to match upstream
+  Keeps an internal deterministic +1 workflow commit when scheduling is enabled
   Syncs main/master branch without affecting your current work
 
 venfork stage <branch>
   Push branch to public fork for PR to upstream
+  Strips internal workflow commits so PR history contains only upstream + user changes
   This is when your work becomes visible to the client`,
     'Available Commands'
   );

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,8 +46,20 @@ async function pathExists(filePath: string): Promise<boolean> {
 const SYNC_WORKFLOW_PATH = getSyncWorkflowPath();
 const WORKFLOW_COMMIT_MESSAGE =
   'chore: add/update scheduled sync workflow (venfork)';
+const WORKFLOWS_DIR = '.github/workflows';
 const VENFORK_BOT_NAME = 'venfork-bot';
 const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
+
+function normalizeWorkflowAllowlist(entries: string[]): string[] {
+  return Array.from(
+    new Set(
+      entries
+        .map((entry) => path.basename(entry.trim()))
+        .filter((entry) => entry.length > 0)
+        .sort()
+    )
+  );
+}
 
 async function commitSubject(
   ref: string,
@@ -184,6 +196,20 @@ async function isScheduleEnabled(cwd?: string): Promise<boolean> {
   return Boolean(config?.schedule?.enabled);
 }
 
+async function listWorkflowFiles(cwd: string): Promise<string[]> {
+  const result = await $({
+    cwd,
+    reject: false,
+  })`git ls-tree -r --name-only HEAD ${WORKFLOWS_DIR}`;
+  if (result.exitCode !== 0 || !result.stdout.trim()) {
+    return [];
+  }
+  return result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
 async function remoteBranchExists(
   remote: string,
   branch: string
@@ -197,10 +223,12 @@ async function remoteBranchExists(
 async function applyScheduledWorkflowCommit(
   defaultBranch: string,
   cron: string,
+  enabledWorkflows: string[],
   cwd?: string
 ): Promise<void> {
   const repoDir = cwd ?? process.cwd();
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-sync-'));
+  const allowlist = normalizeWorkflowAllowlist(enabledWorkflows);
 
   try {
     // Re-stamp from upstream so the private mirror default branch is always
@@ -216,6 +244,25 @@ async function applyScheduledWorkflowCommit(
       generateSyncWorkflow(cron)
     );
     await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
+
+    // If a workflow allowlist is configured, keep only allowed upstream
+    // workflow files plus the venfork-managed sync workflow.
+    if (allowlist.length > 0) {
+      const workflowFiles = await listWorkflowFiles(tempDir);
+      for (const workflowFile of workflowFiles) {
+        if (workflowFile === SYNC_WORKFLOW_PATH) {
+          continue;
+        }
+        const base = path.basename(workflowFile);
+        if (!allowlist.includes(base)) {
+          await $({
+            cwd: tempDir,
+            reject: false,
+          })`git rm --quiet --ignore-unmatch ${workflowFile}`;
+        }
+      }
+    }
+
     await $({
       cwd: tempDir,
     })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit --allow-empty -m ${WORKFLOW_COMMIT_MESSAGE}`;
@@ -905,6 +952,7 @@ export async function syncCommand(
     const repoDir = options?.cwd ?? process.cwd();
     const config = await readVenforkConfigFromRepo(repoDir);
     const scheduleConfig = config?.schedule;
+    const enabledWorkflows = config?.enabledWorkflows ?? [];
 
     // Step 3: Check for divergence
     s.start('Checking for divergent commits');
@@ -974,10 +1022,10 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
 
     await $(
       cwdOpt
-    )`git push origin upstream/${defaultBranch}:${defaultBranch} --force`;
+    )`git push origin upstream/${defaultBranch}:${defaultBranch} --force-with-lease`;
     await $(
       cwdOpt
-    )`git push public upstream/${defaultBranch}:${defaultBranch} --force`;
+    )`git push public upstream/${defaultBranch}:${defaultBranch} --force-with-lease`;
 
     s.stop('Synced to all remotes');
 
@@ -989,6 +1037,7 @@ To force sync anyway: git push origin upstream/${defaultBranch}:${defaultBranch}
       await applyScheduledWorkflowCommit(
         defaultBranch,
         scheduleConfig.cron,
+        enabledWorkflows,
         options?.cwd
       );
       s.stop('Scheduled workflow commit normalized');
@@ -1109,6 +1158,62 @@ export async function scheduleCommand(
     s.stop('Error occurred');
     p.log.error(error instanceof Error ? error.message : String(error));
     p.outro('❌ Schedule command failed');
+    process.exit(1);
+  }
+}
+
+/**
+ * Workflows command: manage workflow allowlist in venfork-config.
+ */
+export async function workflowsCommand(
+  action: 'status' | 'allow' | 'clear',
+  workflows: string[]
+): Promise<void> {
+  p.intro('🧩 Venfork Workflows');
+  const repoDir = process.cwd();
+
+  try {
+    if (action === 'status') {
+      const config = await readVenforkConfigFromRepo(repoDir);
+      if (!config) {
+        throw new Error('venfork-config branch not found or invalid');
+      }
+      const allowlist = config.enabledWorkflows ?? [];
+      if (allowlist.length === 0) {
+        p.note(
+          'No workflow allowlist configured. Mirror keeps all upstream workflows unless schedule logic modifies them.',
+          'Workflows Status'
+        );
+      } else {
+        p.note(
+          allowlist.map((name) => `- ${name}`).join('\n'),
+          'Allowed workflow files'
+        );
+      }
+      p.outro('✨ Workflows status shown');
+      return;
+    }
+
+    if (action === 'clear') {
+      await updateVenforkConfig(repoDir, { enabledWorkflows: null });
+      p.outro(
+        '✨ Workflow allowlist cleared. Run `venfork sync` to apply on the private mirror default branch.'
+      );
+      return;
+    }
+
+    const normalized = normalizeWorkflowAllowlist(workflows);
+    await updateVenforkConfig(repoDir, { enabledWorkflows: normalized });
+    p.note(
+      normalized.map((name) => `- ${name}`).join('\n'),
+      'Allowed workflow files'
+    );
+    p.outro(
+      '✨ Workflow allowlist updated. Run `venfork sync` to apply on the private mirror default branch.'
+    );
+  } catch (error) {
+    p.log.error(error instanceof Error ? error.message : String(error));
+    p.outro('❌ Workflows command failed');
     process.exit(1);
   }
 }
@@ -1341,6 +1446,7 @@ venfork status
 venfork sync [branch]
   Update default branches of origin and public to match upstream
   Re-stamps private default branch as upstream + one internal workflow commit when schedule is enabled
+  Applies workflow allowlist filtering when enabledWorkflows is configured
   Syncs main/master branch without affecting your current work
 
 venfork schedule <status|set <cron>|disable>
@@ -1350,7 +1456,10 @@ venfork schedule <status|set <cron>|disable>
 venfork stage <branch>
   Push branch to public fork for PR to upstream
   When schedule is enabled, strips internal workflow commit before public push
-  This is when your work becomes visible to the client`,
+  This is when your work becomes visible to the client
+
+venfork workflows <status|allow|clear> [workflow-file ...]
+  Configure enabledWorkflows allowlist for mirror workflows in venfork-config`,
     'Available Commands'
   );
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -76,22 +76,22 @@ async function commitTouchesWorkflowPath(
   if (filesResult.exitCode !== 0) {
     return false;
   }
-  const files = filesResult.stdout
+  const changedFiles = filesResult.stdout
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  if (files.length === 0) {
+  if (!changedFiles.length) {
     return false;
   }
-  // Only treat as a workflow-only commit when every changed path is the managed workflow path.
-  return files.every((filePath) => filePath === SYNC_WORKFLOW_PATH);
+  return changedFiles.every((filePath) => filePath === SYNC_WORKFLOW_PATH);
 }
 
 /**
  * Internal workflow commit marker used by the mirror "+1 commit" model.
  *
  * We identify this commit by its deterministic message and also accept commits
- * that change only the managed workflow file, so historical repos can still be normalized.
+ * that change only the managed workflow file, so historical repos can still
+ * be normalized.
  */
 async function isWorkflowCommit(ref: string, cwd?: string): Promise<boolean> {
   const subject = await commitSubject(ref, cwd);

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,7 @@ export interface VenforkConfig {
     enabled: boolean;
   };
   enabledWorkflows?: string[];
+  disabledWorkflows?: string[];
 }
 
 const CONFIG_BRANCH = 'venfork-config';
@@ -26,8 +27,12 @@ const UPDATE_CONFIG_COMMIT_MESSAGE = 'chore: update venfork configuration';
 const VENFORK_BOT_NAME = 'venfork-bot';
 const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
-export type VenforkConfigPatch = Partial<VenforkConfig> & {
+export type VenforkConfigPatch = Omit<
+  Partial<VenforkConfig>,
+  'enabledWorkflows' | 'disabledWorkflows'
+> & {
   enabledWorkflows?: string[] | null;
+  disabledWorkflows?: string[] | null;
 };
 
 /**
@@ -119,6 +124,22 @@ function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
     }
   }
 
+  if (normalized.disabledWorkflows) {
+    const cleaned = Array.from(
+      new Set(
+        normalized.disabledWorkflows
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0)
+          .sort()
+      )
+    );
+    if (cleaned.length > 0) {
+      normalized.disabledWorkflows = cleaned;
+    } else {
+      delete normalized.disabledWorkflows;
+    }
+  }
+
   return normalized;
 }
 
@@ -200,13 +221,19 @@ export async function updateVenforkConfig(
     throw new Error('venfork-config branch not found or invalid');
   }
 
+  const {
+    enabledWorkflows: _enabledWorkflowsPatch,
+    disabledWorkflows: _disabledWorkflowsPatch,
+    ...basePatch
+  } = patch;
+
   const merged: VenforkConfig = {
     ...current,
-    ...patch,
-    schedule: patch.schedule
+    ...basePatch,
+    schedule: basePatch.schedule
       ? {
           ...current.schedule,
-          ...patch.schedule,
+          ...basePatch.schedule,
         }
       : current.schedule,
   };
@@ -217,10 +244,21 @@ export async function updateVenforkConfig(
     merged.enabledWorkflows = patch.enabledWorkflows;
   }
 
+  if (patch.disabledWorkflows === null) {
+    delete merged.disabledWorkflows;
+  } else if (patch.disabledWorkflows !== undefined) {
+    merged.disabledWorkflows = patch.disabledWorkflows;
+  }
+
   if (merged.schedule && !merged.schedule.cron?.trim()) {
     throw new Error('schedule.cron is required when schedule is configured');
   }
 
-  await writeConfigBranch(repoDir, merged, UPDATE_CONFIG_COMMIT_MESSAGE);
-  return merged;
+  const normalized = normalizeConfig(merged);
+  if (!normalized) {
+    throw new Error('Updated venfork config is invalid');
+  }
+
+  await writeConfigBranch(repoDir, normalized, UPDATE_CONFIG_COMMIT_MESSAGE);
+  return normalized;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,94 +1,107 @@
 import { randomBytes } from 'node:crypto';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { $ } from 'execa';
 import { parseRepoPath } from './utils.js';
 
 /**
- * Venfork configuration structure
+ * Venfork configuration structure.
  */
 export interface VenforkConfig {
   version: string;
   publicForkUrl: string;
   upstreamUrl: string;
+  schedule?: {
+    cron: string;
+    enabled: boolean;
+  };
 }
 
 const CONFIG_BRANCH = 'venfork-config';
 const CONFIG_DIR = '.venfork';
 const CONFIG_FILE = 'config.json';
+const UPDATE_CONFIG_COMMIT_MESSAGE = 'chore: update venfork configuration';
 
 /**
- * Creates and pushes a venfork config branch to the origin remote
- *
- * @param repoDir - Local repository directory
- * @param publicForkUrl - URL of the public fork repository
- * @param upstreamUrl - URL of the upstream repository
+ * Creates and pushes a venfork config branch to the origin remote.
  */
 export async function createConfigBranch(
   repoDir: string,
   publicForkUrl: string,
   upstreamUrl: string
 ): Promise<void> {
-  // Create config object
   const config: VenforkConfig = {
     version: '1',
     publicForkUrl,
     upstreamUrl,
   };
 
-  // Generate unique temp directory
+  await writeConfigBranch(repoDir, config, 'Initialize venfork configuration');
+}
+
+async function writeConfigBranch(
+  repoDir: string,
+  config: VenforkConfig,
+  commitMessage: string
+): Promise<void> {
   const uniqueId = randomBytes(8).toString('hex');
   const tempDir = path.join(os.tmpdir(), `venfork-config-${uniqueId}`);
 
   try {
-    // Create temp directory structure
     await mkdir(path.join(tempDir, CONFIG_DIR), { recursive: true });
-
-    // Write config file
     await writeFile(
       path.join(tempDir, CONFIG_DIR, CONFIG_FILE),
       JSON.stringify(config, null, 2)
     );
 
-    // Initialize git repo in temp directory
     await $({ cwd: tempDir })`git init`;
     await $({ cwd: tempDir })`git checkout --orphan ${CONFIG_BRANCH}`;
-
-    // Commit the config
     await $({ cwd: tempDir })`git add ${CONFIG_DIR}/${CONFIG_FILE}`;
-    await $({
-      cwd: tempDir,
-    })`git commit -m ${'Initialize venfork configuration'}`;
+    await $({ cwd: tempDir })`git commit -m ${commitMessage}`;
 
-    // Get the origin remote URL from the main repo
     const remoteResult = await $({ cwd: repoDir })`git remote get-url origin`;
     const originUrl = remoteResult.stdout.trim();
-
-    // Push to origin
     await $({
       cwd: tempDir,
     })`git push ${originUrl} ${CONFIG_BRANCH}:${CONFIG_BRANCH} --force`;
   } finally {
-    // Clean up temp directory
     try {
       await rm(tempDir, { recursive: true, force: true });
     } catch {
-      // Ignore cleanup errors
+      // Ignore cleanup errors.
     }
   }
 }
 
+function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
+  if (!config.version || !config.publicForkUrl || !config.upstreamUrl) {
+    return null;
+  }
+
+  if (config.schedule) {
+    const cron = config.schedule.cron?.trim();
+    if (!cron || typeof config.schedule.enabled !== 'boolean') {
+      return null;
+    }
+    return {
+      ...config,
+      schedule: {
+        cron,
+        enabled: config.schedule.enabled,
+      },
+    };
+  }
+
+  return config;
+}
+
 /**
- * Fetches and reads the venfork config from a repository
- *
- * @param repoUrl - Repository URL to fetch config from
- * @returns Config object if found, null otherwise
+ * Fetches and reads the venfork config from a remote repository.
  */
 export async function fetchVenforkConfig(
   repoUrl: string
 ): Promise<VenforkConfig | null> {
-  // Generate unique temp directory
   const uniqueId = randomBytes(8).toString('hex');
   const tempDir = path.join(os.tmpdir(), `venfork-config-read-${uniqueId}`);
 
@@ -99,34 +112,83 @@ export async function fetchVenforkConfig(
     })`gh repo clone ${repoRef} ${tempDir} -- --branch ${CONFIG_BRANCH} --single-branch --depth 1`;
 
     if (cloneResult.exitCode !== 0) {
-      // Config branch doesn't exist
       return null;
     }
 
-    // Read the config file
-    const configPath = path.join(tempDir, CONFIG_DIR, CONFIG_FILE);
-    const readResult = await $({ reject: false })`cat ${configPath}`;
-
-    if (readResult.exitCode !== 0) {
-      return null;
-    }
-
-    const config = JSON.parse(readResult.stdout) as VenforkConfig;
-
-    // Validate config structure
-    if (!config.version || !config.publicForkUrl || !config.upstreamUrl) {
-      return null;
-    }
-
-    return config;
+    const rawConfig = await readFile(
+      path.join(tempDir, CONFIG_DIR, CONFIG_FILE),
+      'utf-8'
+    );
+    const config = JSON.parse(rawConfig) as VenforkConfig;
+    return normalizeConfig(config);
   } catch {
     return null;
   } finally {
-    // Clean up temp directory
     try {
       await rm(tempDir, { recursive: true, force: true });
     } catch {
-      // Ignore cleanup errors
+      // Ignore cleanup errors.
     }
   }
+}
+
+/**
+ * Reads venfork configuration from the local repo's orphan `venfork-config` branch.
+ */
+export async function readVenforkConfigFromRepo(
+  repoDir: string
+): Promise<VenforkConfig | null> {
+  const fetchResult = await $({
+    cwd: repoDir,
+    reject: false,
+  })`git fetch origin ${CONFIG_BRANCH}`;
+  if (fetchResult.exitCode !== 0) {
+    return null;
+  }
+
+  const showResult = await $({
+    cwd: repoDir,
+    reject: false,
+  })`git show FETCH_HEAD:${CONFIG_DIR}/${CONFIG_FILE}`;
+  if (showResult.exitCode !== 0) {
+    return null;
+  }
+
+  try {
+    const config = JSON.parse(showResult.stdout) as VenforkConfig;
+    return normalizeConfig(config);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Updates and force-pushes `venfork-config` with a shallow merge patch.
+ */
+export async function updateVenforkConfig(
+  repoDir: string,
+  patch: Partial<VenforkConfig>
+): Promise<VenforkConfig> {
+  const current = await readVenforkConfigFromRepo(repoDir);
+  if (!current) {
+    throw new Error('venfork-config branch not found or invalid');
+  }
+
+  const merged: VenforkConfig = {
+    ...current,
+    ...patch,
+    schedule: patch.schedule
+      ? {
+          ...current.schedule,
+          ...patch.schedule,
+        }
+      : current.schedule,
+  };
+
+  if (merged.schedule && !merged.schedule.cron?.trim()) {
+    throw new Error('schedule.cron is required when schedule is configured');
+  }
+
+  await writeConfigBranch(repoDir, merged, UPDATE_CONFIG_COMMIT_MESSAGE);
+  return merged;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,6 +16,7 @@ export interface VenforkConfig {
     cron: string;
     enabled: boolean;
   };
+  enabledWorkflows?: string[];
 }
 
 const CONFIG_BRANCH = 'venfork-config';
@@ -24,6 +25,10 @@ const CONFIG_FILE = 'config.json';
 const UPDATE_CONFIG_COMMIT_MESSAGE = 'chore: update venfork configuration';
 const VENFORK_BOT_NAME = 'venfork-bot';
 const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
+
+export type VenforkConfigPatch = Partial<VenforkConfig> & {
+  enabledWorkflows?: string[] | null;
+};
 
 /**
  * Creates and pushes a venfork config branch to the origin remote.
@@ -83,21 +88,38 @@ function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
     return null;
   }
 
-  if (config.schedule) {
-    const cron = config.schedule.cron?.trim();
-    if (!cron || typeof config.schedule.enabled !== 'boolean') {
+  const normalized: VenforkConfig = {
+    ...config,
+  };
+
+  if (normalized.schedule) {
+    const cron = normalized.schedule.cron?.trim();
+    if (!cron || typeof normalized.schedule.enabled !== 'boolean') {
       return null;
     }
-    return {
-      ...config,
-      schedule: {
-        cron,
-        enabled: config.schedule.enabled,
-      },
+    normalized.schedule = {
+      cron,
+      enabled: normalized.schedule.enabled,
     };
   }
 
-  return config;
+  if (normalized.enabledWorkflows) {
+    const cleaned = Array.from(
+      new Set(
+        normalized.enabledWorkflows
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0)
+          .sort()
+      )
+    );
+    if (cleaned.length > 0) {
+      normalized.enabledWorkflows = cleaned;
+    } else {
+      delete normalized.enabledWorkflows;
+    }
+  }
+
+  return normalized;
 }
 
 /**
@@ -171,7 +193,7 @@ export async function readVenforkConfigFromRepo(
  */
 export async function updateVenforkConfig(
   repoDir: string,
-  patch: Partial<VenforkConfig>
+  patch: VenforkConfigPatch
 ): Promise<VenforkConfig> {
   const current = await readVenforkConfigFromRepo(repoDir);
   if (!current) {
@@ -188,6 +210,12 @@ export async function updateVenforkConfig(
         }
       : current.schedule,
   };
+
+  if (patch.enabledWorkflows === null) {
+    delete merged.enabledWorkflows;
+  } else if (patch.enabledWorkflows !== undefined) {
+    merged.enabledWorkflows = patch.enabledWorkflows;
+  }
 
   if (merged.schedule && !merged.schedule.cron?.trim()) {
     throw new Error('schedule.cron is required when schedule is configured');

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,8 @@ const CONFIG_BRANCH = 'venfork-config';
 const CONFIG_DIR = '.venfork';
 const CONFIG_FILE = 'config.json';
 const UPDATE_CONFIG_COMMIT_MESSAGE = 'chore: update venfork configuration';
+const VENFORK_BOT_NAME = 'venfork-bot';
+const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
 /**
  * Creates and pushes a venfork config branch to the origin remote.
@@ -58,7 +60,9 @@ async function writeConfigBranch(
     await $({ cwd: tempDir })`git init`;
     await $({ cwd: tempDir })`git checkout --orphan ${CONFIG_BRANCH}`;
     await $({ cwd: tempDir })`git add ${CONFIG_DIR}/${CONFIG_FILE}`;
-    await $({ cwd: tempDir })`git commit -m ${commitMessage}`;
+    await $({
+      cwd: tempDir,
+    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit -m ${commitMessage}`;
 
     const remoteResult = await $({ cwd: repoDir })`git remote get-url origin`;
     const originUrl = remoteResult.stdout.trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,10 @@ import {
   stageCommand,
   statusCommand,
   syncCommand,
+  workflowsCommand,
 } from './commands.js';
 import { parseSetupCliArgs } from './setup-args.js';
+import { parseWorkflowsCliArgs } from './workflows-args.js';
 
 /**
  * Main CLI entry point
@@ -55,6 +57,11 @@ async function main(): Promise<void> {
     case 'status':
       await statusCommand();
       break;
+    case 'workflows': {
+      const parsed = parseWorkflowsCliArgs(args.slice(1));
+      await workflowsCommand(parsed.action, parsed.workflows);
+      break;
+    }
     default:
       p.log.error(`Unknown command: ${command}`);
       showHelp();

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as p from '@clack/prompts';
 import {
   cloneCommand,
+  scheduleCommand,
   setupCommand,
   showHelp,
   stageCommand,
@@ -44,6 +45,9 @@ async function main(): Promise<void> {
       break;
     case 'sync':
       await syncCommand(args[1]);
+      break;
+    case 'schedule':
+      await scheduleCommand(args[1], args[2]);
       break;
     case 'stage':
       await stageCommand(args[1]);

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,0 +1,32 @@
+const WORKFLOW_NAME = 'Venfork Sync';
+const WORKFLOW_FILENAME = '.github/workflows/venfork-sync.yml';
+
+export function getSyncWorkflowPath(): string {
+  return WORKFLOW_FILENAME;
+}
+
+/**
+ * Generates deterministic GitHub Actions workflow YAML for scheduled sync.
+ */
+export function generateSyncWorkflow(cron: string): string {
+  return `name: ${WORKFLOW_NAME}
+on:
+  schedule:
+    - cron: '${cron}'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout mirror
+        uses: actions/checkout@v4
+      - name: Install venfork
+        run: npm install -g venfork
+      - name: Sync from upstream
+        run: venfork sync
+`;
+}

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -26,6 +26,23 @@ jobs:
         uses: actions/checkout@v4
       - name: Install venfork
         run: npm install -g venfork
+      - name: Configure venfork remotes
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin venfork-config
+          CONFIG_JSON="$(git show FETCH_HEAD:.venfork/config.json)"
+          UPSTREAM_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.upstreamUrl || '')" "$CONFIG_JSON")"
+          PUBLIC_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.publicForkUrl || '')" "$CONFIG_JSON")"
+          if [ -z "$UPSTREAM_URL" ] || [ -z "$PUBLIC_URL" ]; then
+            echo "Missing upstream/public URL in venfork-config"
+            exit 1
+          fi
+          git remote remove upstream 2>/dev/null || true
+          git remote remove public 2>/dev/null || true
+          git remote add upstream "$UPSTREAM_URL"
+          git remote set-url --push upstream DISABLE
+          git remote add public "$PUBLIC_URL"
       - name: Sync from upstream
         run: venfork sync
 `;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -5,6 +5,13 @@ export function getSyncWorkflowPath(): string {
   return WORKFLOW_FILENAME;
 }
 
+function escapeCronForYaml(cron: string): string {
+  return cron
+    .replace(/'/g, "''")
+    .replace(/[\r\n]+/g, ' ')
+    .trim();
+}
+
 /**
  * Escapes a cron expression for safe inclusion in a single-quoted YAML scalar.
  * Throws if the expression contains characters that cannot appear in a valid cron.

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -6,22 +6,11 @@ export function getSyncWorkflowPath(): string {
 }
 
 function escapeCronForYaml(cron: string): string {
+  // Double single quotes for YAML single-quoted scalars and normalize lines.
   return cron
     .replace(/'/g, "''")
     .replace(/[\r\n]+/g, ' ')
     .trim();
-}
-
-/**
- * Escapes a cron expression for safe inclusion in a single-quoted YAML scalar.
- * Throws if the expression contains characters that cannot appear in a valid cron.
- */
-function escapeCronForYaml(cron: string): string {
-  if (/[\r\n]/.test(cron)) {
-    throw new Error('Cron expression must not contain newline characters');
-  }
-  // Double single quotes for YAML single-quoted scalars.
-  return cron.replace(/'/g, "''");
 }
 
 /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -6,13 +6,26 @@ export function getSyncWorkflowPath(): string {
 }
 
 /**
+ * Escapes a cron expression for safe inclusion in a single-quoted YAML scalar.
+ * Throws if the expression contains characters that cannot appear in a valid cron.
+ */
+function escapeCronForYaml(cron: string): string {
+  if (/[\r\n]/.test(cron)) {
+    throw new Error('Cron expression must not contain newline characters');
+  }
+  // Double single quotes for YAML single-quoted scalars.
+  return cron.replace(/'/g, "''");
+}
+
+/**
  * Generates deterministic GitHub Actions workflow YAML for scheduled sync.
  */
 export function generateSyncWorkflow(cron: string): string {
+  const safeCron = escapeCronForYaml(cron);
   return `name: ${WORKFLOW_NAME}
 on:
   schedule:
-    - cron: '${cron}'
+    - cron: '${safeCron}'
   workflow_dispatch:
 
 permissions:

--- a/src/workflows-args.ts
+++ b/src/workflows-args.ts
@@ -1,0 +1,40 @@
+export type ParsedWorkflowsArgs = {
+  action: 'status' | 'allow' | 'clear';
+  workflows: string[];
+};
+
+/**
+ * Parse `venfork workflows ...` argv after the `workflows` token.
+ */
+export function parseWorkflowsCliArgs(
+  workflowsArgs: string[]
+): ParsedWorkflowsArgs {
+  const actionRaw = workflowsArgs[0] ?? 'status';
+
+  if (actionRaw === 'status') {
+    return { action: 'status', workflows: [] };
+  }
+
+  if (actionRaw === 'clear') {
+    return { action: 'clear', workflows: [] };
+  }
+
+  if (actionRaw === 'allow') {
+    const values = workflowsArgs.slice(1).flatMap((entry) =>
+      entry
+        .split(',')
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0)
+    );
+    if (values.length === 0) {
+      throw new Error(
+        'Usage: venfork workflows allow <workflow-file> [more-workflow-files]'
+      );
+    }
+    return { action: 'allow', workflows: values };
+  }
+
+  throw new Error(
+    'Usage: venfork workflows <status|allow|clear> [workflow-file ...]'
+  );
+}

--- a/src/workflows-args.ts
+++ b/src/workflows-args.ts
@@ -1,5 +1,5 @@
 export type ParsedWorkflowsArgs = {
-  action: 'status' | 'allow' | 'clear';
+  action: 'status' | 'allow' | 'block' | 'clear';
   workflows: string[];
 };
 
@@ -19,7 +19,7 @@ export function parseWorkflowsCliArgs(
     return { action: 'clear', workflows: [] };
   }
 
-  if (actionRaw === 'allow') {
+  if (actionRaw === 'allow' || actionRaw === 'block') {
     const values = workflowsArgs.slice(1).flatMap((entry) =>
       entry
         .split(',')
@@ -28,13 +28,13 @@ export function parseWorkflowsCliArgs(
     );
     if (values.length === 0) {
       throw new Error(
-        'Usage: venfork workflows allow <workflow-file> [more-workflow-files]'
+        `Usage: venfork workflows ${actionRaw} <workflow-file> [more-workflow-files]`
       );
     }
-    return { action: 'allow', workflows: values };
+    return { action: actionRaw, workflows: values };
   }
 
   throw new Error(
-    'Usage: venfork workflows <status|allow|clear> [workflow-file ...]'
+    'Usage: venfork workflows <status|allow|block|clear> [workflow-file ...]'
   );
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -514,7 +514,7 @@ describe('syncCommand', () => {
     ).toBe(true);
     expect(
       execaCalls.some((cmd) =>
-        cmd.includes('git push origin HEAD:main --force')
+        cmd.includes('git push origin HEAD:main --force-with-lease')
       )
     ).toBe(true);
     expect(

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -771,6 +771,32 @@ describe('workflowsCommand', () => {
       )
     ).toBe(true);
   });
+
+  test('updates disabledWorkflows in config branch', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await workflowsCommand('block', ['deploy.yml']);
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('git push') &&
+          cmd.includes('venfork-config:venfork-config')
+      )
+    ).toBe(true);
+  });
 });
 
 describe('setupCommand - organization tests', () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -183,6 +183,7 @@ import {
   stageCommand,
   statusCommand,
   syncCommand,
+  workflowsCommand,
 } from '../src/commands.js';
 
 /**
@@ -716,6 +717,59 @@ describe('showHelp', () => {
 
     // Should not throw and should complete successfully
     expect(true).toBe(true);
+  });
+});
+
+describe('workflowsCommand', () => {
+  test('shows status from config branch', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        enabledWorkflows: ['ci.yml'],
+      }),
+      stderr: '',
+    });
+
+    try {
+      await workflowsCommand('status', []);
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git show FETCH_HEAD:.venfork/config.json')
+      )
+    ).toBe(true);
+  });
+
+  test('updates enabledWorkflows in config branch', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await workflowsCommand('allow', ['ci.yml', 'lint.yml']);
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('git push') &&
+          cmd.includes('venfork-config:venfork-config')
+      )
+    ).toBe(true);
   });
 });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -449,12 +449,12 @@ describe('syncCommand', () => {
 
     expect(
       pushCalls.some((cmd) =>
-        cmd.includes('git push origin upstream/main:main')
+        cmd.includes('git push origin upstream/main:refs/heads/main')
       )
     ).toBe(true);
     expect(
       pushCalls.some((cmd) =>
-        cmd.includes('git push public upstream/main:main')
+        cmd.includes('git push public upstream/main:refs/heads/main')
       )
     ).toBe(true);
   });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -508,7 +508,7 @@ describe('syncCommand', () => {
     expect(
       execaCalls.some((cmd) =>
         cmd.includes(
-          'git commit --allow-empty -m chore: add/update scheduled sync workflow (venfork)'
+          'commit --allow-empty -m chore: add/update scheduled sync workflow (venfork)'
         )
       )
     ).toBe(true);

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -9,6 +9,10 @@ interface RmCall {
   path: string;
   options: { recursive: boolean; force: boolean };
 }
+interface WriteFileCall {
+  path: string;
+  content: string;
+}
 
 type SignalHandler = () => void | Promise<void>;
 type MockResponse =
@@ -18,10 +22,12 @@ type MockResponse =
 // Track calls to our mocks
 const execaCalls: string[] = [];
 const rmCalls: RmCall[] = [];
+const writeFileCalls: WriteFileCall[] = [];
 const signalHandlers = new Map<string, SignalHandler>();
 let shouldHangOnFork = false;
 const mockResponses: Map<string, MockResponse> = new Map();
 let confirmResponse = true; // Default to true for most tests
+let tempDirCounter = 0;
 
 // Store originals
 const originalProcessOn = process.on;
@@ -134,6 +140,15 @@ function getMockExecaResponse(command: string) {
 
 // Mock fs.rm and fs.access BEFORE any imports
 mock.module('node:fs/promises', () => ({
+  mkdtemp: mock((prefix: string) => {
+    tempDirCounter += 1;
+    return Promise.resolve(`${prefix}${tempDirCounter}`);
+  }),
+  mkdir: mock(() => Promise.resolve()),
+  writeFile: mock((path: string, content: string) => {
+    writeFileCalls.push({ path, content });
+    return Promise.resolve();
+  }),
   rm: mock((path: string, options: { recursive: boolean; force: boolean }) => {
     rmCalls.push({ path, options });
     return Promise.resolve();
@@ -193,10 +208,12 @@ beforeEach(() => {
   // Clear tracking arrays
   execaCalls.length = 0;
   rmCalls.length = 0;
+  writeFileCalls.length = 0;
   signalHandlers.clear();
   shouldHangOnFork = false;
   mockResponses.clear();
   confirmResponse = true; // Reset to true for each test
+  tempDirCounter = 0;
 
   // Clear VENFORK_ORG environment variable
   delete process.env.VENFORK_ORG;
@@ -460,9 +477,90 @@ describe('syncCommand', () => {
 
     // Should call git rev-list to check divergence
     const revListCalls = execaCalls.filter((cmd) =>
-      cmd.includes('git rev-list --count')
+      cmd.includes('git rev-list upstream/main..')
     );
     expect(revListCalls.length).toBeGreaterThanOrEqual(2); // Check origin and public
+  });
+
+  test('re-applies deterministic workflow commit when scheduling is enabled', async () => {
+    mockResponses.set('git show origin/main:.github/workflows/sync.yml', {
+      exitCode: 0,
+      stdout: 'name: existing',
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git worktree add --detach'))
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes(
+          'git commit --allow-empty -m chore: add/update scheduled sync workflow (venfork)'
+        )
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git push origin HEAD:main --force')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git push public HEAD:main --force')
+      )
+    ).toBe(true);
+    expect(
+      writeFileCalls.some((w) => w.path.includes('.github/workflows/sync.yml'))
+    ).toBe(true);
+  });
+
+  test('skips workflow commit normalization when scheduling is disabled', async () => {
+    mockResponses.set('git show origin/main:.github/workflows/sync.yml', {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'missing',
+    });
+    mockResponses.set('git show public/main:.github/workflows/sync.yml', {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'missing',
+    });
+    mockResponses.set('git log -1 --format=%s origin/main', {
+      exitCode: 0,
+      stdout: 'normal commit',
+      stderr: '',
+    });
+    mockResponses.set('git log -1 --format=%s public/main', {
+      exitCode: 0,
+      stdout: 'normal commit',
+      stderr: '',
+    });
+    mockResponses.set('git show --name-only --pretty=format: origin/main', {
+      exitCode: 0,
+      stdout: 'README.md',
+      stderr: '',
+    });
+    mockResponses.set('git show --name-only --pretty=format: public/main', {
+      exitCode: 0,
+      stdout: 'README.md',
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git worktree add --detach'))
+    ).toBe(false);
   });
 });
 
@@ -502,6 +600,37 @@ describe('stageCommand', () => {
 
     // Process.exit should have been called
     expect(process.exit).toHaveBeenCalled();
+  });
+
+  test('omits workflow commits from public staging history', async () => {
+    mockResponses.set('git rev-list --reverse upstream/main..feature-branch', {
+      exitCode: 0,
+      stdout: 'workflowsha\nusersha',
+      stderr: '',
+    });
+    mockResponses.set('git log -1 --format=%s workflowsha', {
+      exitCode: 0,
+      stdout: 'chore: add/update scheduled sync workflow (venfork)',
+      stderr: '',
+    });
+    mockResponses.set('git log -1 --format=%s usersha', {
+      exitCode: 0,
+      stdout: 'feat: user change',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git cherry-pick workflowsha'))
+    ).toBe(false);
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git cherry-pick usersha'))
+    ).toBe(true);
   });
 });
 
@@ -874,9 +1003,9 @@ describe('cloneCommand - error paths', () => {
 describe('syncCommand - error paths', () => {
   test('aborts when origin has divergent commits', async () => {
     // Mock rev-list to show origin has divergent commits
-    mockResponses.set('git rev-list --count upstream/main..origin/main', {
+    mockResponses.set('git rev-list upstream/main..origin/main', {
       exitCode: 0,
-      stdout: '3',
+      stdout: 'abc123\n',
       stderr: '',
     });
 
@@ -891,9 +1020,9 @@ describe('syncCommand - error paths', () => {
 
   test('aborts when public has divergent commits', async () => {
     // Mock rev-list to show public has divergent commits
-    mockResponses.set('git rev-list --count upstream/main..public/main', {
+    mockResponses.set('git rev-list upstream/main..public/main', {
       exitCode: 0,
-      stdout: '2',
+      stdout: 'def456\n',
       stderr: '',
     });
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -149,6 +149,7 @@ mock.module('node:fs/promises', () => ({
     writeFileCalls.push({ path, content });
     return Promise.resolve();
   }),
+  readFile: mock(() => Promise.reject(new Error('ENOENT'))),
   rm: mock((path: string, options: { recursive: boolean; force: boolean }) => {
     rmCalls.push({ path, options });
     return Promise.resolve();
@@ -176,6 +177,7 @@ mock.module('@clack/prompts', () => ({
 // Import commands (will use mocked execa, fs, and prompts)
 import {
   cloneCommand,
+  scheduleCommand,
   setupCommand,
   showHelp,
   stageCommand,
@@ -483,9 +485,14 @@ describe('syncCommand', () => {
   });
 
   test('re-applies deterministic workflow commit when scheduling is enabled', async () => {
-    mockResponses.set('git show origin/main:.github/workflows/sync.yml', {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
       exitCode: 0,
-      stdout: 'name: existing',
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        schedule: { enabled: true, cron: '0 */6 * * *' },
+      }),
       stderr: '',
     });
 
@@ -514,41 +521,23 @@ describe('syncCommand', () => {
       execaCalls.some((cmd) =>
         cmd.includes('git push public HEAD:main --force')
       )
-    ).toBe(true);
+    ).toBe(false);
     expect(
-      writeFileCalls.some((w) => w.path.includes('.github/workflows/sync.yml'))
+      writeFileCalls.some((w) =>
+        w.path.includes('.github/workflows/venfork-sync.yml')
+      )
     ).toBe(true);
   });
 
   test('skips workflow commit normalization when scheduling is disabled', async () => {
-    mockResponses.set('git show origin/main:.github/workflows/sync.yml', {
-      exitCode: 1,
-      stdout: '',
-      stderr: 'missing',
-    });
-    mockResponses.set('git show public/main:.github/workflows/sync.yml', {
-      exitCode: 1,
-      stdout: '',
-      stderr: 'missing',
-    });
-    mockResponses.set('git log -1 --format=%s origin/main', {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
       exitCode: 0,
-      stdout: 'normal commit',
-      stderr: '',
-    });
-    mockResponses.set('git log -1 --format=%s public/main', {
-      exitCode: 0,
-      stdout: 'normal commit',
-      stderr: '',
-    });
-    mockResponses.set('git show --name-only --pretty=format: origin/main', {
-      exitCode: 0,
-      stdout: 'README.md',
-      stderr: '',
-    });
-    mockResponses.set('git show --name-only --pretty=format: public/main', {
-      exitCode: 0,
-      stdout: 'README.md',
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        schedule: { enabled: false, cron: '0 */6 * * *' },
+      }),
       stderr: '',
     });
 
@@ -603,19 +592,14 @@ describe('stageCommand', () => {
   });
 
   test('omits workflow commits from public staging history', async () => {
-    mockResponses.set('git rev-list --reverse upstream/main..feature-branch', {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
       exitCode: 0,
-      stdout: 'workflowsha\nusersha',
-      stderr: '',
-    });
-    mockResponses.set('git log -1 --format=%s workflowsha', {
-      exitCode: 0,
-      stdout: 'chore: add/update scheduled sync workflow (venfork)',
-      stderr: '',
-    });
-    mockResponses.set('git log -1 --format=%s usersha', {
-      exitCode: 0,
-      stdout: 'feat: user change',
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        schedule: { enabled: true, cron: '0 */6 * * *' },
+      }),
       stderr: '',
     });
 
@@ -626,10 +610,75 @@ describe('stageCommand', () => {
     }
 
     expect(
-      execaCalls.some((cmd) => cmd.includes('git cherry-pick workflowsha'))
-    ).toBe(false);
+      execaCalls.some((cmd) =>
+        cmd.includes('git rebase --onto upstream/main origin/main')
+      )
+    ).toBe(true);
     expect(
-      execaCalls.some((cmd) => cmd.includes('git cherry-pick usersha'))
+      execaCalls.some(
+        (cmd) => cmd.includes('git push public') && cmd.includes('--force')
+      )
+    ).toBe(true);
+  });
+});
+
+describe('scheduleCommand', () => {
+  test('sets schedule and writes workflow/config updates', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await scheduleCommand('set', '0 */6 * * *');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git show FETCH_HEAD:.venfork/config.json')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('git push') &&
+          cmd.includes('venfork-config:venfork-config')
+      )
+    ).toBe(true);
+    expect(
+      writeFileCalls.some((w) =>
+        w.path.includes('.github/workflows/venfork-sync.yml')
+      )
+    ).toBe(true);
+  });
+
+  test('disables schedule and removes workflow from default branch', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        schedule: { enabled: true, cron: '0 */6 * * *' },
+      }),
+      stderr: '',
+    });
+
+    try {
+      await scheduleCommand('disable');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git rm --quiet --ignore-unmatch'))
     ).toBe(true);
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type MockResponse =
+  | { exitCode: number; stdout: string; stderr: string }
+  | ((command: string) => Promise<unknown>);
+
+const execaCalls: string[] = [];
+const mockResponses: Map<string, MockResponse> = new Map();
+const writeFileCalls: Array<{ path: string; content: string }> = [];
+
+mock.module('execa', () => ({
+  // biome-ignore lint/suspicious/noExplicitAny: Execa template mocks use flexible args.
+  $: mock((stringsOrOptions: TemplateStringsArray | any, ...values: any[]) => {
+    let command: string;
+
+    if (
+      typeof stringsOrOptions === 'object' &&
+      !Array.isArray(stringsOrOptions)
+    ) {
+      // biome-ignore lint/suspicious/noExplicitAny: Template literal values type.
+      return mock((strings: TemplateStringsArray, ...vals: any[]) => {
+        command = String.raw({ raw: strings }, ...vals);
+        execaCalls.push(command);
+        return getMockExecaResponse(command);
+      });
+    }
+
+    command = String.raw({ raw: stringsOrOptions }, ...values);
+    execaCalls.push(command);
+    return getMockExecaResponse(command);
+  }),
+}));
+
+mock.module('node:fs/promises', () => ({
+  mkdir: mock(() => Promise.resolve()),
+  rm: mock(() => Promise.resolve()),
+  readFile: mock(() =>
+    Promise.resolve(
+      JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/public.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+      })
+    )
+  ),
+  writeFile: mock((path: string, content: string) => {
+    writeFileCalls.push({ path, content });
+    return Promise.resolve();
+  }),
+}));
+
+function getMockExecaResponse(command: string) {
+  for (const [pattern, response] of mockResponses.entries()) {
+    if (command.includes(pattern)) {
+      return typeof response === 'function'
+        ? response(command)
+        : Promise.resolve(response);
+    }
+  }
+
+  if (command.includes('git fetch origin venfork-config')) {
+    return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+  }
+  if (command.includes('git show FETCH_HEAD:.venfork/config.json')) {
+    return Promise.resolve({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/public.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+      }),
+      stderr: '',
+    });
+  }
+  if (command.includes('git remote get-url origin')) {
+    return Promise.resolve({
+      exitCode: 0,
+      stdout: 'git@github.com:test/private.git',
+      stderr: '',
+    });
+  }
+
+  return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+}
+
+import {
+  readVenforkConfigFromRepo,
+  updateVenforkConfig,
+} from '../src/config.js';
+
+beforeEach(() => {
+  execaCalls.length = 0;
+  writeFileCalls.length = 0;
+  mockResponses.clear();
+});
+
+describe('readVenforkConfigFromRepo', () => {
+  test('returns parsed config from orphan branch', async () => {
+    const result = await readVenforkConfigFromRepo('/tmp/repo');
+    expect(result).toEqual({
+      version: '1',
+      publicForkUrl: 'git@github.com:test/public.git',
+      upstreamUrl: 'git@github.com:upstream/repo.git',
+    });
+  });
+});
+
+describe('updateVenforkConfig', () => {
+  test('merges schedule patch and writes updated config branch', async () => {
+    const updated = await updateVenforkConfig('/tmp/repo', {
+      schedule: { enabled: true, cron: '0 */6 * * *' },
+    });
+
+    expect(updated.schedule).toEqual({ enabled: true, cron: '0 */6 * * *' });
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('git push') &&
+          cmd.includes('venfork-config:venfork-config')
+      )
+    ).toBe(true);
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    expect(writeFileCalls[0].content).toContain('"schedule"');
+  });
+});

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -122,4 +122,21 @@ describe('updateVenforkConfig', () => {
     expect(writeFileCalls.length).toBeGreaterThan(0);
     expect(writeFileCalls[0].content).toContain('"schedule"');
   });
+
+  test('stores normalized enabled/disabled workflow policy', async () => {
+    const updated = await updateVenforkConfig('/tmp/repo', {
+      enabledWorkflows: [' ci.yml ', 'lint.yml', 'ci.yml'],
+      disabledWorkflows: ['deploy.yml', ' deploy.yml '],
+    });
+
+    expect(updated.enabledWorkflows).toEqual(['ci.yml', 'lint.yml']);
+    expect(updated.disabledWorkflows).toEqual(['deploy.yml']);
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    expect(writeFileCalls[writeFileCalls.length - 1].content).toContain(
+      '"enabledWorkflows"'
+    );
+    expect(writeFileCalls[writeFileCalls.length - 1].content).toContain(
+      '"disabledWorkflows"'
+    );
+  });
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { generateSyncWorkflow, getSyncWorkflowPath } from '../src/workflow.js';
+
+describe('workflow helpers', () => {
+  test('returns managed workflow path', () => {
+    expect(getSyncWorkflowPath()).toBe('.github/workflows/venfork-sync.yml');
+  });
+
+  test('generates deterministic workflow with cron and dispatch trigger', () => {
+    const workflow = generateSyncWorkflow('0 */6 * * *');
+    expect(workflow).toContain("cron: '0 */6 * * *'");
+    expect(workflow).toContain('workflow_dispatch');
+    expect(workflow).toContain('run: venfork sync');
+  });
+});

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -12,4 +12,9 @@ describe('workflow helpers', () => {
     expect(workflow).toContain('workflow_dispatch');
     expect(workflow).toContain('run: venfork sync');
   });
+
+  test('escapes cron safely for yaml single-quoted string', () => {
+    const workflow = generateSyncWorkflow("0 */6 * * *'\n# injected");
+    expect(workflow).toContain("cron: '0 */6 * * *'' # injected'");
+  });
 });

--- a/tests/workflows-args.test.ts
+++ b/tests/workflows-args.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import { parseWorkflowsCliArgs } from '../src/workflows-args.js';
+
+describe('parseWorkflowsCliArgs', () => {
+  test('defaults to status', () => {
+    expect(parseWorkflowsCliArgs([])).toEqual({
+      action: 'status',
+      workflows: [],
+    });
+  });
+
+  test('parses allow values and normalizes comma-separated input', () => {
+    expect(
+      parseWorkflowsCliArgs(['allow', 'ci.yml,lint.yml', 'build.yml'])
+    ).toEqual({
+      action: 'allow',
+      workflows: ['ci.yml', 'lint.yml', 'build.yml'],
+    });
+  });
+
+  test('parses clear command', () => {
+    expect(parseWorkflowsCliArgs(['clear'])).toEqual({
+      action: 'clear',
+      workflows: [],
+    });
+  });
+
+  test('throws for allow without values', () => {
+    expect(() => parseWorkflowsCliArgs(['allow'])).toThrow();
+  });
+
+  test('throws for unknown action', () => {
+    expect(() => parseWorkflowsCliArgs(['unknown'])).toThrow();
+  });
+});

--- a/tests/workflows-args.test.ts
+++ b/tests/workflows-args.test.ts
@@ -25,8 +25,19 @@ describe('parseWorkflowsCliArgs', () => {
     });
   });
 
+  test('parses block values', () => {
+    expect(parseWorkflowsCliArgs(['block', 'deploy.yml', 'e2e.yml'])).toEqual({
+      action: 'block',
+      workflows: ['deploy.yml', 'e2e.yml'],
+    });
+  });
+
   test('throws for allow without values', () => {
     expect(() => parseWorkflowsCliArgs(['allow'])).toThrow();
+  });
+
+  test('throws for block without values', () => {
+    expect(() => parseWorkflowsCliArgs(['block'])).toThrow();
   });
 
   test('throws for unknown action', () => {


### PR DESCRIPTION
## Summary

This PR implements config-driven scheduled sync for Venfork using a managed GitHub Actions workflow, while preserving clean public PR history.
The private mirror default branch now follows a stable invariant when scheduling is enabled.
`private/default = upstream/default + exactly 1 internal workflow commit`

## Linked Issue
   #13
## Update Details

- Added schedule settings to venfork-config
    - schedule.enabled
    - schedule.cron
- Added a new workflow generator in src/workflow.ts for:
    - .github/workflows/venfork-sync.yml
- Added new command:
    - venfork schedule status
    - venfork schedule set "<cron>"
    - venfork schedule disable
- Updated venfork sync:
    - still force-syncs from upstream
    - then, if schedule is enabled, adds one deterministic workflow commit on top
- Updated venfork stage:
    - when schedule is enabled, strips the internal workflow commit before pushing to public
    - when disabled, keeps normal push behavior
- Routed schedule in src/index.ts
- Updated README docs

## Why
GitHub Actions workflow must exist on default branch.
This makes private mirror intentionally upstream + 1 internal commit when scheduling is on, but ensures that internal commit never appears in upstream-facing PRs.

