### PR TITLE
fix(docs): clarify scheduled sync branch rules (+1 mirror model)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ venfork setup my-org/foo my-foo-private --org my-org --fork-name foo-public
 - Clones the private mirror into `./<private-mirror-name>`, or **reuses** that directory if it is already a git repo whose `origin` points at the expected mirror URL.
 - Ensures `public` and `upstream` remotes exist and point at the right URLs (adds or corrects them).
 - Pushes the `venfork-config` branch again so teammates get current URLs.
-- If **either** GitHub repo was already present, runs **`venfork sync` inside that clone** so default branches on `origin` and `public` match `upstream` (subject to the usual divergence safeguards).
+- If **either** GitHub repo was already present, runs **`venfork sync` inside that clone** so defaults are normalized from `upstream` (subject to divergence safeguards): `public` matches upstream, while `origin` may include one managed workflow commit when scheduled sync is enabled.
 
 Pure failures (for example name taken by a **different** repo) still abort setup. If recovery sync stops due to divergent default branches, fix or move those commits, then run **`venfork sync`** again from inside the private mirror.
 
@@ -192,7 +192,9 @@ venfork clone git@github.com:acme-corp/awesome-project-private.git
 
 ### `venfork sync [branch]`
 
-Update the default branches of your private mirror and public fork to match upstream.
+Update default branches from upstream. With scheduled sync enabled, the private mirror uses a managed `+1` model:
+- `public/<default>` matches `upstream/<default>`
+- `origin/<default>` is `upstream/<default>` plus one deterministic managed workflow commit
 
 Normally you run this from your private mirror directory (or any subfolder of that repo). The same behavior is also used internally when **`venfork setup`** completes in recovery mode (existing GitHub repos), using the new clone’s path automatically.
 
@@ -216,7 +218,8 @@ venfork sync develop   # Sync develop branch with upstream/develop
 6. **Does not affect your current working branch or feature branches**
 
 **Important:**
-- This keeps your default branches (main/master) in sync with upstream
+- With scheduled sync enabled, mirror default branch follows the `upstream + 1 managed commit` model
+- Public default branch remains aligned with upstream
 - Your current work on feature branches is completely unaffected
 - If divergent commits are detected, sync will abort to prevent data loss
 


### PR DESCRIPTION
## Summary

This updates documentation to clearly explain the branch invariants required for scheduled syncs to work in Venfork’s managed model.

When scheduled sync is enabled, Venfork intentionally uses a mirror `+1` default-branch strategy:

- `public/<default>` == `upstream/<default>`
- `origin/<default>` == `upstream/<default>` + exactly one managed commit:
  - `chore: add/update scheduled sync workflow (venfork)`

The README now reflects this behavior explicitly so users understand why the private mirror can be one commit ahead by design.

## Why this was needed

Scheduled GitHub Actions require a workflow file committed on the default branch.  
That requirement conflicts with strict mirror-equality unless we define and enforce branch rules.

The documented rules make the model predictable and safe:

- private mirror default branch may carry one internal managed commit
- public fork default branch stays aligned with upstream
- `venfork stage` strips managed internal changes from public-facing history

## Branch rules (documented)

1. `upstream/<default>` is the source of truth.
2. `venfork sync` first normalizes from upstream to both remotes.
3. If schedule is enabled, Venfork reapplies one deterministic managed workflow commit on `origin/<default>`.
4. Workflow filtering policy (`enabledWorkflows` / `disabledWorkflows`) is applied as part of that managed commit.
5. `venfork stage` excludes managed workflow commits so external PRs contain only upstream + user feature changes.

## Operational notes

- Divergence safeguards still apply before sync.
- Running sync repeatedly remains idempotent under the managed `+1` model.
- First-run bootstrap requires creating/updating destination branch refs correctly (now handled by fully-qualified ref push target).

## Validation

- Command tests pass.
- Lint passes.
- Manual smoke checks confirm:
  - managed `+1` behavior on mirror default branch
  - public default branch remains aligned with upstream
  - workflow policy application behaves as documented