### PR TITLE
fix(setup): support owner/repo shorthand in fork path

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ venfork setup git@github.com:client/project.git internal-mirror --org my-company
 # Upstream is already my-org/foo — fork under my-org with a different public repo name
 venfork setup my-org/foo my-foo-private --org my-org --fork-name foo-public
 # Creates: my-org/my-foo-private (private), my-org/foo-public (public fork), upstream = my-org/foo
+
+# Shorthand also works with --org + --fork-name (equivalent to git@github.com:firebase/extensions.git)
+venfork setup firebase/extensions firebase-extensions-private --org invertase --fork-name firebase-extensions
 ```
 
 **Re-running setup (repos already on GitHub):** Run the same command again if you need a fresh local clone, remote fixes, or an updated `venfork-config` branch. Venfork uses `gh repo view` to detect a public fork or private mirror that already exists when `gh repo fork` or `gh repo create` fails, then:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,7 +52,18 @@ export function parseRepoName(url: string): string {
  * parseRepoPath("https://github.com/vercel/next.js.git") // "vercel/next.js"
  */
 export function parseRepoPath(url: string): string {
-  const match = url.match(/github\.com[:/](.+?)(?:\.git)?$/);
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  // Accept already-short owner/repo input too, so callers that need
+  // a GH repo path stay robust even if normalization is skipped.
+  if (/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+(?:\.git)?$/.test(trimmed)) {
+    return trimmed.endsWith('.git') ? trimmed.slice(0, -4) : trimmed;
+  }
+
+  const match = trimmed.match(/github\.com[:/](.+?)(?:\.git)?$/);
   return match?.[1] || '';
 }
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -859,6 +859,26 @@ describe('setupCommand - organization tests', () => {
     ).toBe(true);
   });
 
+  test('handles owner/repo shorthand with --org and --fork-name', async () => {
+    try {
+      await setupCommand(
+        'firebase/extensions',
+        'firebase-extensions-private',
+        'invertase',
+        'firebase-extensions'
+      );
+    } catch {
+      // Expected
+    }
+
+    const forkCalls = execaCalls.filter((cmd) => cmd.includes('gh repo fork'));
+    expect(forkCalls.length).toBeGreaterThan(0);
+    expect(forkCalls[0]).toContain('gh repo fork firebase/extensions');
+    expect(forkCalls[0]).not.toContain("gh repo fork ''");
+    expect(forkCalls[0]).toContain('--org invertase');
+    expect(forkCalls[0]).toContain('--fork-name firebase-extensions');
+  });
+
   test('uses organization in git URLs when specified', async () => {
     try {
       await setupCommand(

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -99,6 +99,16 @@ describe('parseRepoName', () => {
 });
 
 describe('parseRepoPath', () => {
+  test('accepts owner/repo shorthand directly', () => {
+    expect(parseRepoPath('firebase/extensions')).toBe('firebase/extensions');
+  });
+
+  test('accepts owner/repo.git shorthand directly', () => {
+    expect(parseRepoPath('firebase/extensions.git')).toBe(
+      'firebase/extensions'
+    );
+  });
+
   test('extracts owner/repo from SSH URL with .git', () => {
     expect(parseRepoPath('git@github.com:facebook/react.git')).toBe(
       'facebook/react'


### PR DESCRIPTION
## Summary

Fixes `venfork setup` failing when upstream is passed as shorthand `owner/repo` with `--org` / `--fork-name`.

Before this change, the setup flow could pass an empty repo argument to `gh repo fork` in the shorthand path (e.g. `gh repo fork '' ...`), causing setup to fail. Shorthand input now resolves consistently and safely across the fork path.

Closes #24.

## What Changed

- Updated repo-path parsing to accept direct shorthand safely:
  - `owner/repo`
  - `owner/repo.git`
- Ensured setup fork invocation uses a valid upstream repo path in shorthand flows.
- Added regression tests for the exact repro scenario:
  - `venfork setup firebase/extensions firebase-extensions-private --org invertase --fork-name firebase-extensions`
  - Assert fork command contains `firebase/extensions` and not `''`.
- Added utility tests for shorthand parsing behavior.
- Added README example showing shorthand with `--org` + `--fork-name`.

## Why

README already documents shorthand as supported, so shorthand and full URL forms should behave identically in setup. This aligns implementation with documented behavior and prevents a blocking setup failure for org-based workflows.

## Repro (from issue)
`venfork setup firebase/extensions firebase-extensions-private --org invertase --fork-name firebase-extensions`


Expected now: setup proceeds without passing an empty repo to `gh repo fork`.