### PR TITLE
fix(setup): validate reused public repo is fork of upstream

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -23,6 +23,7 @@ import {
   getGitHubUsername,
   getRemotes,
   ghRepoExists,
+  ghRepoIsForkOf,
   hasRemote,
   isGitRepository,
 } from './git.js';
@@ -592,6 +593,15 @@ export async function setupCommand(
           forkResult.stderr.trim() ||
             forkResult.stdout.trim() ||
             'gh repo fork failed'
+        );
+      }
+      const isExpectedFork = await ghRepoIsForkOf(
+        publicForkFullName,
+        upstreamRepoPath
+      );
+      if (!isExpectedFork) {
+        throw new Error(
+          `Cannot reuse ${publicForkFullName} as public fork: it is not a fork of ${upstreamRepoPath}. Choose a different --fork-name.`
         );
       }
       forkPreexisted = true;

--- a/src/git.ts
+++ b/src/git.ts
@@ -118,6 +118,22 @@ export async function ghRepoExists(fullName: string): Promise<boolean> {
 }
 
 /**
+ * Returns true when `repoFullName` exists and is a fork of `upstreamFullName`.
+ */
+export async function ghRepoIsForkOf(
+  repoFullName: string,
+  upstreamFullName: string
+): Promise<boolean> {
+  const result = await $({
+    reject: false,
+  })`gh repo view ${repoFullName} --json isFork,parent --jq '.isFork and .parent.nameWithOwner == "${upstreamFullName}"'`;
+  if (result.exitCode !== 0) {
+    return false;
+  }
+  return result.stdout.trim() === 'true';
+}
+
+/**
  * Gets the default branch for a remote
  *
  * @param remote - Remote name (default: 'upstream')

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -123,6 +123,16 @@ function getMockExecaResponse(command: string) {
       stderr: '',
     });
   }
+  if (
+    command.includes('gh repo view') &&
+    command.includes('--json isFork,parent')
+  ) {
+    return Promise.resolve({
+      exitCode: 0,
+      stdout: 'true',
+      stderr: '',
+    });
+  }
   if (command.includes('gh repo view')) {
     // Checking if public fork exists
     return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
@@ -395,6 +405,28 @@ describe('setupCommand - idempotent recovery', () => {
     expect(cloneCalls.some((c) => c.includes('test/repo'))).toBe(true);
     expect(cloneCalls.some((c) => c.includes('test-vendor'))).toBe(true);
     expect(execaCalls.some((c) => c.includes('git fetch upstream'))).toBe(true);
+  });
+
+  test('fails when default-name repo exists but is not a fork of upstream', async () => {
+    mockResponses.set('gh repo fork', {
+      exitCode: 1,
+      stderr: 'already exists',
+      stdout: '',
+    });
+    mockResponses.set('--json isFork,parent', {
+      exitCode: 0,
+      stdout: 'false',
+      stderr: '',
+    });
+
+    await expect(
+      setupCommand(
+        'git@github.com:firebase/extensions.git',
+        'firebase-extensions-private',
+        'invertase',
+        'firebase-extensions'
+      )
+    ).rejects.toThrow('process.exit called');
   });
 
   test('fails when private mirror create fails and repo is not found on GitHub', async () => {

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -105,6 +105,7 @@ import {
   getGitHubUsername,
   getRemotes,
   ghRepoExists,
+  ghRepoIsForkOf,
   hasRemote,
   isGitRepository,
 } from '../src/git';
@@ -570,6 +571,59 @@ describe('ghRepoExists', () => {
     });
 
     const result = await ghRepoExists('acme/missing');
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('ghRepoIsForkOf', () => {
+  test('returns true when repo is a fork of expected upstream', async () => {
+    mockResponses.set(
+      'gh repo view invertase/firebase-extensions --json isFork,parent',
+      {
+        exitCode: 0,
+        stdout: 'true',
+        stderr: '',
+      }
+    );
+
+    const result = await ghRepoIsForkOf(
+      'invertase/firebase-extensions',
+      'firebase/extensions'
+    );
+
+    expect(result).toBe(true);
+  });
+
+  test('returns false when repo is not a fork of expected upstream', async () => {
+    mockResponses.set(
+      'gh repo view invertase/extensions --json isFork,parent',
+      {
+        exitCode: 0,
+        stdout: 'false',
+        stderr: '',
+      }
+    );
+
+    const result = await ghRepoIsForkOf(
+      'invertase/extensions',
+      'firebase/extensions'
+    );
+
+    expect(result).toBe(false);
+  });
+
+  test('returns false when gh repo view fails', async () => {
+    mockResponses.set('gh repo view invertase/missing --json isFork,parent', {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'Not Found',
+    });
+
+    const result = await ghRepoIsForkOf(
+      'invertase/missing',
+      'firebase/extensions'
+    );
 
     expect(result).toBe(false);
   });


### PR DESCRIPTION
## Summary

Fixes a setup safety bug where `venfork setup` could silently reuse an unrelated pre-existing repository as the `public` remote when fork creation fell into the idempotent-reuse path.

This change adds explicit validation: if a candidate existing repo is reused as the public fork, it must actually be a fork of the requested upstream. Otherwise setup now fails with a clear error instead of misconfiguring remotes.

## What Changed

- Added `ghRepoIsForkOf(repoFullName, upstreamFullName)` in `src/git.ts`.
  - Uses `gh repo view --json isFork,parent` to verify fork lineage.
- Updated `setupCommand` in `src/commands.ts`:
  - In the `gh repo fork` failure/reuse path, after confirming repo existence, now verifies it is a fork of the intended upstream.
  - If not, throws a clear error instructing to use a different `--fork-name`.
- Added regression coverage in `tests/commands.test.ts`:
  - New failing test for Issue #25 scenario (existing non-fork repo should not be reused).
  - Existing idempotent-reuse behavior remains valid when the repo is a proper fork.
- Added unit tests for `ghRepoIsForkOf` in `tests/git.test.ts`.

## Why

Without lineage verification, setup can bind `public` to the wrong repository, creating a latent and potentially dangerous footgun for future `venfork stage` pushes.

This update makes reuse explicit and safe:
- reuse only when the existing repo is the correct fork target
- fail loudly otherwise

## Repro Covered

Issue repro path with org + custom fork name and an unrelated pre-existing default-name repo now fails safely instead of silently reusing the wrong repo.