### PR TITLE
feat: stage --pr, pull-request, sync <pulled-branch>, and issue stage/pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,34 @@ venfork sync upstream-pr/1234
 
 In that case it refetches `pull/<n>/head` from upstream and force-with-lease pushes the result to origin. The default-branch sync (the +1-managed-commit flow) is unaffected.
 
+### `venfork issue <stage|pull> <number-or-url> [--title <text>]`
+
+Move *issue* context between the private mirror and upstream — the same shape as `stage --pr` and `pull-request`, but for issues instead of PRs.
+
+**Sub-commands:**
+- `stage <internal-#>` — read an internal triage issue from the mirror, redact `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks (same convention as `stage --pr`), and open the upstream counterpart via `gh issue create`.
+- `pull <upstream-#>` — read an upstream issue, create a parallel internal issue on the mirror titled `[upstream #N] <original title>` so the team can triage it without leaving the private space.
+
+**Flags:**
+- `--title <text>` - Override the destination issue's title.
+
+**Examples:**
+```bash
+# Found a bug while working internally → refine then file upstream
+venfork issue stage 7
+
+# Watching an upstream issue that affects the team's roadmap
+venfork issue pull 1234
+```
+
+**What gets recorded**
+
+Both sub-commands write a linkage to `venfork-config`:
+- `shippedIssues[<internal-#>]` for `stage`
+- `pulledIssues[<internal-#>]` for `pull`
+
+This is **only the linkage** — comments and state changes do *not* sync. If the upstream issue is closed, the internal one stays open until you close it manually (and vice versa). Treat the records as a "where did this go?" audit log rather than a live mirror.
+
 ### `venfork schedule <status|set <cron>|disable>`
 
 Manage automated sync configuration stored in `venfork-config`.

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Pull a third-party upstream PR into the private mirror so your team can review i
 - `pr-number-or-url` - Either a bare integer (`1234`) or a github.com PR URL.
 
 **Flags:**
-- `--branch-name <name>` - Use a custom local/mirror branch name instead of `upstream-pr/<n>`.
+- `--branch-name <name>` - Use a custom local/mirror branch name instead of `upstream-pr/<n>`. **Note**: with a custom branch name, the linkage in `venfork-config.pulledPrs[<branch>]` is the only way `venfork sync <branch>` finds the upstream PR — the `upstream-pr/<n>` convention fallback only matches branches with that exact name.
 - `--no-push` - Fetch into a local branch only; don't push to the mirror.
 
 **Examples:**
@@ -487,6 +487,10 @@ VENFORK_NONINTERACTIVE=1 venfork stage feat/auth --pr
 ```
 
 The setup-time personal-account confirmation is intentionally **not** bypassed — that one's a safety net you almost certainly want when scripting setup.
+
+### Concurrency
+
+Commands that mutate `venfork-config` (`stage --pr`, `pull-request`, `issue stage`, `issue pull`, and `sync upstream-pr/<n>`) push to the orphan config branch with `--force-with-lease`. Two parallel runs racing the config update will see the **second** push fail with a "stale info" error — re-run the failed command and the next read will include the first run's update. Don't `--force` the config branch by hand to "fix" the failure; that's exactly the data-loss path the lease prevents.
 
 ## Complete Workflow
 

--- a/README.md
+++ b/README.md
@@ -478,6 +478,16 @@ venfork setup git@github.com:client/project.git
 # Continue with personal account? (y/N)
 ```
 
+### `VENFORK_NONINTERACTIVE`
+
+Set `VENFORK_NONINTERACTIVE=1` to auto-confirm prompts in `venfork stage --pr`, `venfork issue stage`, and `venfork issue pull`. Useful when calling venfork from CI or scripts where stdin isn't a TTY.
+
+```bash
+VENFORK_NONINTERACTIVE=1 venfork stage feat/auth --pr
+```
+
+The setup-time personal-account confirmation is intentionally **not** bypassed — that one's a safety net you almost certainly want when scripting setup.
+
 ## Complete Workflow
 
 ### Initial Setup

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ venfork status
 - Check which remotes are configured
 - See your current branch
 
-### `venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]`
+### `venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>] [--internal-pr <n>] [--no-update-existing]`
 
 Push a branch to the public fork, making it visible and ready for PR to upstream. With `--pr`, also opens the upstream PR for you using your internal review PR's body.
 
@@ -273,6 +273,8 @@ Push a branch to the public fork, making it visible and ready for PR to upstream
 - `--draft` - Open the upstream PR as a draft. Implies `--pr`.
 - `--title <text>` - Override the upstream PR title (default: the internal PR title, or the branch name if no internal PR was found).
 - `--base <branch>` - Override the upstream base branch (default: upstream's default branch).
+- `--internal-pr <n>` - Pin a specific internal-review PR number (skips the most-recent-open lookup). Useful when multiple PRs target the same branch.
+- `--no-update-existing` - Do not update an already-open upstream PR body when staging. By default, if an upstream PR for the branch already exists, `venfork stage --pr` refreshes its body with the latest translated content.
 
 **Examples:**
 ```bash
@@ -318,7 +320,7 @@ Internal note: Client X explicitly asked us to use Auth0 instead of Keycloak (se
 The implementation follows the spec at https://example.com/oauth.
 ```
 
-`venfork stage --pr` strips everything between the markers (greedy multi-line) before posting upstream. The upstream PR shows only the public summary; the internal context stays inside the redacted block on the private mirror, where only your team can see it.
+`venfork stage --pr` strips all content enclosed by these markers before posting upstream. The upstream PR shows only the public summary; the internal context stays inside the redacted block on the private mirror, where only your team can see it.
 
 If you forget to add markers, the entire internal body is sent upstream — review the preview prompt before confirming.
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,11 @@ The setup-time personal-account confirmation is intentionally **not** bypassed �
 
 ### Concurrency
 
-Commands that mutate `venfork-config` (`stage --pr`, `pull-request`, `issue stage`, `issue pull`, and `sync upstream-pr/<n>`) push to the orphan config branch with `--force-with-lease`. Two parallel runs racing the config update will see the **second** push fail with a "stale info" error — re-run the failed command and the next read will include the first run's update. Don't `--force` the config branch by hand to "fix" the failure; that's exactly the data-loss path the lease prevents.
+Commands that mutate `venfork-config` (`stage --pr`, `pull-request`, `issue stage`, `issue pull`, and `sync upstream-pr/<n>`) push to the orphan config branch with `--force-with-lease=venfork-config:<read-sha>`, leasing against the exact SHA the command read its starting state from.
+
+When two venfork commands race the config update, the losing one's push is rejected with a "stale info" error. **venfork auto-handles this**: it re-reads the freshly-updated config (now including the winning run's changes), re-applies its own patch on top, and pushes again with the new lease SHA. Up to 3 retries before giving up.
+
+That means concurrent runs are normally invisible to the user — both updates land. Only after sustained contention (3 lease failures in a row) does venfork surface the error and ask you to re-run the command. Don't `--force` the config branch by hand to "fix" a transient lease failure; that's exactly the data-loss path the lease prevents.
 
 ## Complete Workflow
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,21 @@ git push origin feature/new-thing
 # Still private! Create internal PR for team review
 
 # 3. Stage for upstream (after internal approval)
+venfork stage feature/new-thing --pr
+# NOW visible on public fork — and the upstream PR is opened for you,
+# carrying your internal review body (with <!-- venfork:internal --> blocks redacted).
+
+# Or just stage and open the PR yourself later:
 venfork stage feature/new-thing
-# NOW visible on public fork
-# Create PR: public fork → upstream
+```
+
+```bash
+# Reviewing a third-party upstream PR internally
+venfork pull-request 1234
+# upstream-pr/1234 now exists on the mirror; team can review/test against your internal codebase
+
+# Refresh as the upstream contributor pushes updates
+venfork sync upstream-pr/1234
 ```
 
 ## Commands
@@ -247,27 +259,111 @@ venfork status
 - Check which remotes are configured
 - See your current branch
 
-### `venfork stage <branch>`
+### `venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]`
 
-Push a branch to the public fork, making it visible and ready for PR to upstream.
+Push a branch to the public fork, making it visible and ready for PR to upstream. With `--pr`, also opens the upstream PR for you using your internal review PR's body.
 
 **⚠️ Important:** This is when your work becomes visible to the client!
 
 **Arguments:**
 - `branch` - Branch name to stage
 
+**Flags:**
+- `--pr` - Also open an upstream PR after staging. Looks up your internal-review PR on the private mirror and copies its description (with redacted blocks stripped — see below) into the upstream PR.
+- `--draft` - Open the upstream PR as a draft. Implies `--pr`.
+- `--title <text>` - Override the upstream PR title (default: the internal PR title, or the branch name if no internal PR was found).
+- `--base <branch>` - Override the upstream base branch (default: upstream's default branch).
+
 **Examples:**
 ```bash
+# Stage only — same as before
 venfork stage feature-auth
-venfork stage bugfix/issue-123
+
+# Stage and open the upstream PR using the internal review body
+venfork stage feature-auth --pr
+
+# Open as draft
+venfork stage feature-auth --draft
+
+# Override title or base
+venfork stage feature-auth --pr --title "Add OAuth"
+venfork stage feature-auth --pr --base develop
 ```
 
-**What it does:**
+**What it does (without `--pr`):**
 1. Verifies branch exists
 2. Shows staging details and confirmation
 3. Rebuilds branch history on top of upstream while removing internal workflow commits
 4. Pushes sanitized history to public fork
-5. Provides PR creation link
+5. Provides a compare URL so you can open the PR yourself
+
+**What `--pr` adds:**
+1. Looks up the most recent PR on the private mirror with `--head <branch>` (open first, then most recent of any state).
+2. Renders the upstream PR body by stripping any `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks and appending a footer linking back to the internal review.
+3. Shows you the translated body **before** confirming, so you can catch redaction mistakes before they go public.
+4. Runs `gh pr create --repo <upstream> --base <default> --head <fork-owner>:<branch>` and surfaces the resulting PR URL.
+5. Records the linkage in `venfork-config.shippedBranches[<branch>]` for later tracking.
+
+**Redacting internal-only context**
+
+In the body of your internal review PR, wrap anything that should NOT go upstream in HTML comments:
+
+```md
+This PR adds OAuth login.
+
+<!-- venfork:internal -->
+Internal note: Client X explicitly asked us to use Auth0 instead of Keycloak (see ticket INT-1234).
+<!-- /venfork:internal -->
+
+The implementation follows the spec at https://example.com/oauth.
+```
+
+`venfork stage --pr` strips everything between the markers (greedy multi-line) before posting upstream. The upstream PR shows only the public summary; the internal context stays inside the redacted block on the private mirror, where only your team can see it.
+
+If you forget to add markers, the entire internal body is sent upstream — review the preview prompt before confirming.
+
+### `venfork pull-request <pr-number-or-url> [--branch-name <override>] [--no-push]`
+
+Pull a third-party upstream PR into the private mirror so your team can review it internally before it lands. The PR's commits land on a new branch (`upstream-pr/<n>` by default) that's pushed to your mirror.
+
+**Arguments:**
+- `pr-number-or-url` - Either a bare integer (`1234`) or a github.com PR URL.
+
+**Flags:**
+- `--branch-name <name>` - Use a custom local/mirror branch name instead of `upstream-pr/<n>`.
+- `--no-push` - Fetch into a local branch only; don't push to the mirror.
+
+**Examples:**
+```bash
+# Bring upstream PR #1234 into the mirror
+venfork pull-request 1234
+
+# Or via URL
+venfork pull-request https://github.com/upstream/repo/pull/1234
+
+# Use a custom branch name (e.g. for staged team review of a critical PR)
+venfork pull-request 1234 --branch-name review/oauth-pr
+```
+
+**What it does:**
+1. Reads the upstream PR's metadata (`gh pr view`) and prints a summary (title, author, state, base, body preview, link).
+2. Fetches `pull/<n>/head` from the upstream remote into a local branch.
+3. Pushes that branch to `origin` (the private mirror) so the team can see it.
+4. Records a `pulledPrs[<branch>]` entry in `venfork-config` so `venfork sync <branch>` knows which upstream PR to refresh from.
+
+**Refreshing a pulled PR**
+
+When the upstream contributor updates their PR, refresh your local + mirror copy with:
+
+```bash
+venfork sync upstream-pr/1234
+```
+
+`venfork sync <branch>` falls into the pulled-PR path when:
+- `venfork-config.pulledPrs[<branch>]` exists (recorded by `pull-request`), OR
+- The branch matches the `upstream-pr/<n>` naming convention.
+
+In that case it refetches `pull/<n>/head` from upstream and force-with-lease pushes the result to origin. The default-branch sync (the +1-managed-commit flow) is unaffected.
 
 ### `venfork schedule <status|set <cron>|disable>`
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "venfork",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2146,6 +2146,263 @@ export async function pullRequestCommand(
   }
 }
 
+interface IssueMeta {
+  number: number;
+  url: string;
+  title: string;
+  body: string;
+  state: string;
+  author?: { login: string };
+}
+
+async function readIssue(
+  repoPath: string,
+  number: number,
+  cwd: string
+): Promise<IssueMeta> {
+  const result = await $({
+    cwd,
+    reject: false,
+  })`gh issue view ${number} --repo ${repoPath} --json number,url,title,body,state,author`;
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to read issue #${number} from ${repoPath}: ${result.stderr.trim() || `exit ${result.exitCode}`}`
+    );
+  }
+  return JSON.parse(result.stdout) as IssueMeta;
+}
+
+async function createIssue(args: {
+  repoPath: string;
+  title: string;
+  body: string;
+  cwd: string;
+}): Promise<{ url: string; number: number }> {
+  const result = await $({
+    cwd: args.cwd,
+    reject: false,
+    input: args.body,
+  })`gh issue create --repo ${args.repoPath} --title ${args.title} --body-file -`;
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to create issue on ${args.repoPath}: ${result.stderr.trim() || `exit ${result.exitCode}`}`
+    );
+  }
+  const url = result.stdout.trim().split(/\s+/).pop() ?? '';
+  const numberMatch = url.match(/\/issues\/(\d+)/);
+  if (!numberMatch) {
+    throw new Error(`gh issue create returned an unexpected output: ${url}`);
+  }
+  return { url, number: Number(numberMatch[1]) };
+}
+
+function resolveIssueArg(
+  target: string,
+  expectedRepoPath: string
+): { number: number } {
+  const trimmed = target.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return { number: Number(trimmed) };
+  }
+  const match = trimmed.match(
+    /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?\/issues\/(\d+)/
+  );
+  if (!match) {
+    throw new Error(
+      `Could not parse issue reference: ${target}. Expected an integer or a github.com/<owner>/<repo>/issues/<n> URL.`
+    );
+  }
+  const [, sourceRepoPath, num] = match;
+  if (sourceRepoPath !== expectedRepoPath) {
+    p.log.warn(
+      `Issue URL points to ${sourceRepoPath}, but the expected repo is ${expectedRepoPath}. Continuing under that assumption.`
+    );
+  }
+  return { number: Number(num) };
+}
+
+/**
+ * Issue command: stage an internal issue to upstream, or pull an upstream
+ * issue into the mirror for internal triage. Body translation uses the same
+ * `<!-- venfork:internal -->...<!-- /venfork:internal -->` markers as
+ * `stage --pr`. No comment sync — the linkage is one-shot.
+ */
+export async function issueCommand(
+  action: 'stage' | 'pull' | undefined,
+  target: string | undefined,
+  options: { title?: string } = {}
+): Promise<void> {
+  p.intro('🐛 Venfork Issue');
+
+  const isAuthenticated = await checkGhAuth();
+  if (!isAuthenticated) {
+    throw new AuthenticationError();
+  }
+
+  if (!action || !target) {
+    p.log.error(
+      'Usage: venfork issue <stage|pull> <number-or-url> [--title <text>]'
+    );
+    p.outro('');
+    process.exit(1);
+  }
+
+  const s = p.spinner();
+  const repoDir = process.cwd();
+
+  try {
+    s.start('Resolving remotes');
+    const upstreamUrlResult = await $({
+      cwd: repoDir,
+      reject: false,
+    })`git remote get-url upstream`;
+    if (upstreamUrlResult.exitCode !== 0) {
+      throw new RemoteNotFoundError('upstream');
+    }
+    const upstreamRepoPath = parseRepoPath(upstreamUrlResult.stdout.trim());
+    if (!upstreamRepoPath) {
+      throw new Error(
+        `Could not parse upstream remote URL: ${upstreamUrlResult.stdout.trim()}`
+      );
+    }
+    const mirrorRepoPath = await findMirrorRepoPath(repoDir);
+    if (!mirrorRepoPath) {
+      throw new RemoteNotFoundError('origin');
+    }
+    s.stop(`Mirror: ${mirrorRepoPath} | Upstream: ${upstreamRepoPath}`);
+
+    if (action === 'stage') {
+      const { number: internalNumber } = resolveIssueArg(
+        target,
+        mirrorRepoPath
+      );
+
+      s.start(`Reading internal issue #${internalNumber}`);
+      const internal = await readIssue(mirrorRepoPath, internalNumber, repoDir);
+      s.stop(`Read: ${internal.title}`);
+
+      const translatedBody = translateInternalBody(internal.body, internal.url);
+      const upstreamTitle = options.title ?? internal.title;
+
+      p.note(
+        [
+          `Internal: #${internal.number} ${internal.title} (${internal.state})`,
+          `Upstream target: ${upstreamRepoPath}`,
+          '',
+          `Title: ${upstreamTitle}`,
+        ].join('\n'),
+        'Issue Stage'
+      );
+      p.note(translatedBody || '(empty)', 'Upstream issue body preview');
+
+      const ok = await p.confirm({
+        message: `Open the issue on ${upstreamRepoPath}?`,
+        initialValue: false,
+      });
+      if (p.isCancel(ok) || !ok) {
+        p.outro('Stage cancelled');
+        process.exit(0);
+      }
+
+      s.start('Opening upstream issue');
+      const created = await createIssue({
+        repoPath: upstreamRepoPath,
+        title: upstreamTitle,
+        body: translatedBody,
+        cwd: repoDir,
+      });
+      s.stop(`Upstream issue created: ${created.url}`);
+
+      try {
+        await updateVenforkConfig(repoDir, {
+          shippedIssues: {
+            [String(internalNumber)]: {
+              internalIssueNumber: internalNumber,
+              internalIssueUrl: internal.url,
+              upstreamIssueNumber: created.number,
+              upstreamIssueUrl: created.url,
+              shippedAt: new Date().toISOString(),
+            },
+          },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.log.warn(`Could not record shippedIssues entry: ${msg}`);
+      }
+
+      p.outro(`✨ Issue staged: ${created.url}`);
+      return;
+    }
+
+    // action === 'pull'
+    const { number: upstreamNumber } = resolveIssueArg(
+      target,
+      upstreamRepoPath
+    );
+
+    s.start(`Reading upstream issue #${upstreamNumber}`);
+    const upstream = await readIssue(upstreamRepoPath, upstreamNumber, repoDir);
+    s.stop(`Read: ${upstream.title} (${upstream.state})`);
+
+    const internalTitle =
+      options.title ?? `[upstream #${upstream.number}] ${upstream.title}`;
+    const internalBody = `${upstream.body || '(no body provided)'}\n\n> Pulled from upstream issue: ${upstream.url}\n> Author: ${upstream.author?.login ?? '(unknown)'}\n> State: ${upstream.state}`;
+
+    p.note(
+      [
+        `Upstream: #${upstream.number} ${upstream.title} (${upstream.state})`,
+        `Mirror target: ${mirrorRepoPath}`,
+        '',
+        `Title: ${internalTitle}`,
+      ].join('\n'),
+      'Issue Pull'
+    );
+    p.note(internalBody, 'Internal issue body preview');
+
+    const ok = await p.confirm({
+      message: `Open the issue on ${mirrorRepoPath}?`,
+      initialValue: false,
+    });
+    if (p.isCancel(ok) || !ok) {
+      p.outro('Pull cancelled');
+      process.exit(0);
+    }
+
+    s.start('Opening internal issue');
+    const created = await createIssue({
+      repoPath: mirrorRepoPath,
+      title: internalTitle,
+      body: internalBody,
+      cwd: repoDir,
+    });
+    s.stop(`Internal issue created: ${created.url}`);
+
+    try {
+      await updateVenforkConfig(repoDir, {
+        pulledIssues: {
+          [String(created.number)]: {
+            upstreamIssueNumber: upstreamNumber,
+            upstreamIssueUrl: upstream.url,
+            internalIssueNumber: created.number,
+            internalIssueUrl: created.url,
+            pulledAt: new Date().toISOString(),
+          },
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      p.log.warn(`Could not record pulledIssues entry: ${msg}`);
+    }
+
+    p.outro(`✨ Issue pulled: ${created.url}`);
+  } catch (error) {
+    s.stop('Error occurred');
+    p.log.error(error instanceof Error ? error.message : String(error));
+    p.outro('❌ Issue command failed');
+    process.exit(1);
+  }
+}
+
 /**
  * Status command: Show current repository setup and configuration
  */
@@ -2270,6 +2527,13 @@ venfork pull-request <pr-number-or-url> [--branch-name <name>] [--no-push]
   Fetches pull/<n>/head from upstream into a new branch (default: upstream-pr/<n>)
   Pushes the branch to origin so the team can see it
   Refresh later with: venfork sync <branch>
+
+venfork issue <stage|pull> <number-or-url> [--title <text>]
+  Move issue context between the private mirror and upstream
+  • stage: read internal mirror issue, strip venfork:internal blocks,
+    open the upstream counterpart, record linkage in venfork-config
+  • pull: read upstream issue, open an internal triage issue on the mirror,
+    record linkage. No comment sync — the linkage is one-shot.
 
 venfork workflows <status|allow|block|clear> [workflow-file ...]
   Configure workflow allowlist/blocklist policy in venfork-config`,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -9,6 +9,7 @@ import {
   fetchVenforkConfig,
   readVenforkConfigFromRepo,
   updateVenforkConfig,
+  type VenforkConfig,
 } from './config.js';
 import {
   AuthenticationError,
@@ -1050,6 +1051,93 @@ export async function cloneCommand(vendorRepoUrl?: string): Promise<void> {
 /**
  * Sync command: Update default branches of origin and public to match upstream
  */
+/**
+ * Returns the upstream PR number for `branch` if it's a pulled-in PR. First
+ * checks `venfork-config.pulledPrs` (recorded by `venfork pull-request`),
+ * then falls back to the `upstream-pr/<n>` naming convention. Returns null
+ * if the branch is not a pulled PR (sync routes to the default flow).
+ */
+function resolvePulledPr(
+  branch: string,
+  config: VenforkConfig | null
+): { prNumber: number; tracked: boolean } | null {
+  const recorded = config?.pulledPrs?.[branch];
+  if (recorded?.upstreamPrNumber) {
+    return { prNumber: recorded.upstreamPrNumber, tracked: true };
+  }
+  const conventionMatch = branch.match(/^upstream-pr\/(\d+)$/);
+  if (conventionMatch) {
+    return { prNumber: Number(conventionMatch[1]), tracked: false };
+  }
+  return null;
+}
+
+async function syncPulledPr(
+  branch: string,
+  prNumber: number,
+  cwd: string,
+  s: ReturnType<typeof p.spinner>
+): Promise<void> {
+  s.start(`Fetching pull/${prNumber}/head from upstream`);
+  const fetchResult = await $({
+    cwd,
+    reject: false,
+  })`git fetch upstream pull/${prNumber}/head:${branch}`;
+  if (fetchResult.exitCode !== 0) {
+    // git fetch refuses to clobber a divergent local branch; force into the
+    // local ref since the source of truth for pulled PRs is upstream.
+    const forceResult = await $({
+      cwd,
+      reject: false,
+    })`git fetch upstream +pull/${prNumber}/head:${branch}`;
+    if (forceResult.exitCode !== 0) {
+      throw new Error(
+        `git fetch upstream pull/${prNumber}/head failed:\n${(forceResult.stderr || fetchResult.stderr).trim()}`
+      );
+    }
+  }
+  const headSha = (await $({ cwd })`git rev-parse ${branch}`).stdout.trim();
+  s.stop(`Fetched ${headSha.slice(0, 9)} → ${branch}`);
+
+  s.start(`Pushing ${branch} to origin`);
+  const pushResult = await $({
+    cwd,
+    reject: false,
+  })`git push origin ${branch} --force-with-lease`;
+  if (pushResult.exitCode !== 0) {
+    s.stop('Push failed');
+    p.log.warn(
+      `Could not push ${branch} to origin: ${pushResult.stderr.trim()}`
+    );
+    p.log.warn('Local branch is updated; the mirror copy was not.');
+  } else {
+    s.stop(`Pushed ${branch} to origin`);
+  }
+
+  try {
+    await updateVenforkConfig(cwd, {
+      pulledPrs: {
+        [branch]: {
+          upstreamPrNumber: prNumber,
+          upstreamPrUrl: `https://github.com/${(
+            await $({ cwd })`git remote get-url upstream`
+          ).stdout
+            .trim()
+            .replace(
+              /.*[:/]([^/]+\/[^/]+?)(?:\.git)?$/,
+              '$1'
+            )}/pull/${prNumber}`,
+          head: headSha,
+          lastSyncedAt: new Date().toISOString(),
+        },
+      },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    p.log.warn(`Could not update pulledPrs entry: ${msg}`);
+  }
+}
+
 export async function syncCommand(
   targetBranch?: string,
   options?: { cwd?: string; quiet?: boolean }
@@ -1064,6 +1152,25 @@ export async function syncCommand(
   const s = p.spinner();
 
   try {
+    const repoDir = options?.cwd ?? process.cwd();
+
+    // Branch-specific path: if the targetBranch is a pulled-in upstream PR,
+    // refresh it from `pull/<n>/head` instead of running the default-branch
+    // +1-commit sync flow.
+    if (targetBranch) {
+      const initialConfig = await readVenforkConfigFromRepo(repoDir);
+      const pulledPr = resolvePulledPr(targetBranch, initialConfig);
+      if (pulledPr) {
+        await syncPulledPr(targetBranch, pulledPr.prNumber, repoDir, s);
+        if (!quiet) {
+          p.outro(
+            `✨ ${targetBranch} synced with upstream PR #${pulledPr.prNumber}`
+          );
+        }
+        return;
+      }
+    }
+
     // Step 1: Fetch from upstream
     s.start('Fetching from upstream');
     await $(cwdOpt)`git fetch upstream`;
@@ -1074,7 +1181,6 @@ export async function syncCommand(
     // Step 2: Detect default branch if not specified
     const defaultBranch =
       targetBranch || (await getDefaultBranch('upstream', options?.cwd));
-    const repoDir = options?.cwd ?? process.cwd();
     const config = await readVenforkConfigFromRepo(repoDir);
     const scheduleConfig = config?.schedule;
     const enabledWorkflows = config?.enabledWorkflows ?? [];
@@ -1498,10 +1604,156 @@ async function executeStagingPush(
   return headResult.stdout.trim();
 }
 
+export interface StageOptions {
+  /** When true, also open an upstream PR after staging. */
+  createPr?: boolean;
+  /** When true, the upstream PR is opened as a draft. Implies createPr. */
+  draft?: boolean;
+  /** Override the upstream PR title; default is the internal PR title. */
+  title?: string;
+  /** Override the upstream base branch; default is upstream's default branch. */
+  base?: string;
+}
+
+interface InternalPrInfo {
+  number: number;
+  url: string;
+  title: string;
+  body: string;
+}
+
+const VENFORK_INTERNAL_REDACTION_RE =
+  /<!--\s*venfork:internal\s*-->[\s\S]*?<!--\s*\/venfork:internal\s*-->/g;
+
 /**
- * Stage command: Push branch to public fork for PR to upstream
+ * Looks up the most relevant internal PR for `branch` on the private mirror.
+ * Prefers the most recent open PR; falls back to the most recent of any state.
+ * Returns null if none exists or the lookup fails (network/rate limit) — the
+ * caller falls back to a synthetic body.
  */
-export async function stageCommand(branch: string): Promise<void> {
+async function findInternalPr(
+  mirrorRepoPath: string,
+  branch: string,
+  cwd: string
+): Promise<InternalPrInfo | null> {
+  // Prefer an open PR; if none, take the most recent of any state.
+  for (const stateFlag of ['--state open', '--state all']) {
+    const result = await $({
+      cwd,
+      reject: false,
+    })`gh pr list --repo ${mirrorRepoPath} --head ${branch} ${stateFlag} --json number,url,title,body --limit 1`;
+    if (result.exitCode !== 0) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(result.stdout) as InternalPrInfo[];
+      if (parsed.length > 0) {
+        return parsed[0];
+      }
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Strips `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks and
+ * appends a footer linking back to the internal review PR (only the team can
+ * follow that link; the upstream maintainer sees only that there *was* an
+ * internal review).
+ */
+function translateInternalBody(
+  body: string,
+  internalPrUrl: string | undefined
+): string {
+  const stripped = body.replace(VENFORK_INTERNAL_REDACTION_RE, '').trim();
+  const footer = internalPrUrl
+    ? `\n\n> Upstreamed from internal review (${internalPrUrl}).`
+    : '';
+  return `${stripped}${footer}`.trim();
+}
+
+/**
+ * Build the body and title for the upstream PR. Falls back to a synthetic body
+ * keyed off the branch name when there's no internal PR to translate.
+ */
+function buildUpstreamPrPayload(
+  branch: string,
+  internal: InternalPrInfo | null,
+  override: { title?: string; body?: string }
+): { title: string; body: string } {
+  if (internal) {
+    return {
+      title: override.title ?? internal.title,
+      body: override.body ?? translateInternalBody(internal.body, internal.url),
+    };
+  }
+  return {
+    title: override.title ?? branch,
+    body:
+      override.body ??
+      `Branch staged from a venfork-managed private mirror. No internal review PR found for \`${branch}\`; please add a description.`,
+  };
+}
+
+/**
+ * Creates the upstream PR via gh and returns its URL. Surfaces the duplicate-PR
+ * case ("already exists") cleanly so the caller can recover.
+ */
+async function createUpstreamPr(args: {
+  upstreamRepoPath: string;
+  publicOwner: string;
+  branch: string;
+  base: string;
+  title: string;
+  body: string;
+  draft: boolean;
+  cwd: string;
+}): Promise<{ url: string; alreadyExists: boolean }> {
+  const head = `${args.publicOwner}:${args.branch}`;
+  const result = await $({
+    cwd: args.cwd,
+    reject: false,
+    input: args.body,
+  })`gh pr create --repo ${args.upstreamRepoPath} --base ${args.base} --head ${head} --title ${args.title} --body-file - ${args.draft ? '--draft' : []}`;
+
+  if (result.exitCode === 0) {
+    return { url: result.stdout.trim(), alreadyExists: false };
+  }
+  // gh prints something like "a pull request for branch X into branch Y already exists: https://..."
+  const combined = `${result.stdout}\n${result.stderr}`;
+  const existing = combined.match(/https?:\/\/\S*\/pull\/\d+/);
+  if (existing && /already exists/i.test(combined)) {
+    return { url: existing[0], alreadyExists: true };
+  }
+  throw new Error(
+    `Failed to create upstream PR via gh: ${combined.trim() || `exit ${result.exitCode}`}`
+  );
+}
+
+async function findMirrorRepoPath(cwd: string): Promise<string | null> {
+  const result = await $({
+    cwd,
+    reject: false,
+  })`git remote get-url origin`;
+  if (result.exitCode !== 0) return null;
+  const path = parseRepoPath(result.stdout.trim());
+  return path || null;
+}
+
+/**
+ * Stage command: Push branch to public fork for PR to upstream.
+ *
+ * With `--pr` (createPr), additionally opens the upstream PR using the
+ * internal-review PR's body as a starting point (with `<!-- venfork:internal
+ * -->...<!-- /venfork:internal -->` blocks stripped) and records the
+ * internal/upstream PR linkage in `venfork-config.shippedBranches`.
+ */
+export async function stageCommand(
+  branch: string | undefined,
+  options: StageOptions = {}
+): Promise<void> {
   p.intro('📤 Venfork Stage');
 
   const isAuthenticated = await checkGhAuth();
@@ -1511,9 +1763,13 @@ export async function stageCommand(branch: string): Promise<void> {
 
   if (!branch) {
     p.log.error('Branch name is required');
-    p.outro('Usage: venfork stage <branch>');
+    p.outro(
+      'Usage: venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]'
+    );
     process.exit(1);
   }
+
+  const createPr = Boolean(options.createPr || options.draft);
 
   const s = p.spinner();
   const repoDir = process.cwd();
@@ -1523,18 +1779,60 @@ export async function stageCommand(branch: string): Promise<void> {
     const plan = await planStaging(branch, repoDir);
     s.stop('Branch verified');
 
-    p.note(
-      `Branch '${plan.branch}' will be pushed to your public fork.
-This makes your work visible and ready for PR to upstream.
+    // Look up the internal PR up-front when --pr is set so the user sees the
+    // translated body in the confirm prompt before anything is published.
+    let internalPr: InternalPrInfo | null = null;
+    let translatedBody = '';
+    let prTitle = '';
+    const baseBranch = options.base ?? plan.upstreamDefaultBranch;
+    if (createPr) {
+      s.start('Looking up internal review PR');
+      const mirrorRepoPath = await findMirrorRepoPath(repoDir);
+      if (mirrorRepoPath) {
+        internalPr = await findInternalPr(mirrorRepoPath, plan.branch, repoDir);
+      }
+      const payload = buildUpstreamPrPayload(plan.branch, internalPr, {
+        title: options.title,
+      });
+      prTitle = payload.title;
+      translatedBody = payload.body;
+      s.stop(
+        internalPr
+          ? `Internal PR found: ${internalPr.url}`
+          : 'No internal PR found — using synthetic body'
+      );
+    }
 
-  From: Private vendor repo (current)
-  To:   ${plan.publicUrl}
-  PR:   ${plan.publicRepoPath} → ${plan.upstreamRepoPath}`,
-      'Staging Details'
-    );
+    const detailLines = [
+      `Branch '${plan.branch}' will be pushed to your public fork.`,
+      'This makes your work visible and ready for PR to upstream.',
+      '',
+      `  From: Private vendor repo (current)`,
+      `  To:   ${plan.publicUrl}`,
+      `  PR:   ${plan.publicRepoPath} → ${plan.upstreamRepoPath}`,
+    ];
+    if (createPr) {
+      detailLines.push(
+        '',
+        `  Upstream PR: ${prTitle}`,
+        `  Base:        ${plan.upstreamRepoPath}@${baseBranch}`,
+        `  Draft:       ${options.draft ? 'yes' : 'no'}`
+      );
+    }
+    p.note(detailLines.join('\n'), 'Staging Details');
+
+    if (createPr) {
+      const previewBody =
+        translatedBody.length > 800
+          ? `${translatedBody.slice(0, 800)}\n…(truncated; full body sent on submit)`
+          : translatedBody;
+      p.note(previewBody || '(empty)', 'Upstream PR body preview');
+    }
 
     const shouldStage = await p.confirm({
-      message: 'Push to public fork?',
+      message: createPr
+        ? 'Push to public fork and open the upstream PR?'
+        : 'Push to public fork?',
       initialValue: false,
     });
 
@@ -1548,20 +1846,302 @@ This makes your work visible and ready for PR to upstream.
       process.exit(0);
     }
 
-    await executeStagingPush(plan, repoDir, s);
+    const stagedHead = await executeStagingPush(plan, repoDir, s);
+
+    let upstreamPrUrl: string | undefined;
+    let alreadyExisted = false;
+    if (createPr) {
+      s.start('Opening upstream pull request');
+      try {
+        const result = await createUpstreamPr({
+          upstreamRepoPath: plan.upstreamRepoPath,
+          publicOwner: plan.publicOwner,
+          branch: plan.branch,
+          base: baseBranch,
+          title: prTitle,
+          body: translatedBody,
+          draft: Boolean(options.draft),
+          cwd: repoDir,
+        });
+        upstreamPrUrl = result.url;
+        alreadyExisted = result.alreadyExists;
+        s.stop(
+          alreadyExisted
+            ? `Upstream PR already exists: ${upstreamPrUrl}`
+            : `Upstream PR opened: ${upstreamPrUrl}`
+        );
+      } catch (err) {
+        s.stop('Upstream PR creation failed');
+        const msg = err instanceof Error ? err.message : String(err);
+        p.log.warn(msg);
+        p.log.warn(
+          'Staging succeeded; you can retry the PR manually with `gh pr create`.'
+        );
+      }
+    }
+
+    if (createPr && upstreamPrUrl) {
+      try {
+        await updateVenforkConfig(repoDir, {
+          shippedBranches: {
+            [plan.branch]: {
+              upstreamPrUrl,
+              head: stagedHead,
+              shippedAt: new Date().toISOString(),
+              ...(internalPr ? { internalPrUrl: internalPr.url } : {}),
+            },
+          },
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        p.log.warn(`Could not record shippedBranches entry: ${msg}`);
+      }
+    }
 
     const prUrl = `https://github.com/${plan.upstreamRepoPath}/compare/${plan.upstreamDefaultBranch}...${plan.publicOwner}:${plan.branch}?expand=1`;
 
-    p.note(
-      `Your branch is now on the public fork!\n\nCreate a pull request to upstream:\n  ${prUrl}`,
-      'Next Steps'
-    );
+    if (createPr && upstreamPrUrl) {
+      const lines = [`Upstream PR: ${upstreamPrUrl}`];
+      if (internalPr) {
+        lines.push(`Internal review: ${internalPr.url}`);
+      }
+      p.note(lines.join('\n'), 'Next Steps');
+    } else {
+      p.note(
+        `Your branch is now on the public fork!\n\nCreate a pull request to upstream:\n  ${prUrl}\n\n(Tip: re-run with --pr to open it automatically.)`,
+        'Next Steps'
+      );
+    }
 
     p.outro('✨ Stage complete!');
   } catch (error) {
     s.stop('Error occurred');
     p.log.error(error instanceof Error ? error.message : String(error));
     p.outro('❌ Stage failed');
+    process.exit(1);
+  }
+}
+
+export interface PullRequestOptions {
+  /** Local + mirror branch name to write the PR's commits to. */
+  branchName?: string;
+  /** When false, only fetch locally; do not push to the mirror. */
+  push?: boolean;
+}
+
+/**
+ * Resolves a `<pr>` argument (bare number or PR URL) to a numeric PR id.
+ * For URL form, also returns the parsed owner/repo so the caller can sanity
+ * check it matches the upstream remote.
+ */
+function resolvePullRequestArg(
+  pr: string,
+  upstreamRepoPath: string
+): { number: number; sourceRepoPath?: string } {
+  const trimmed = pr.trim();
+  if (/^\d+$/.test(trimmed)) {
+    return { number: Number(trimmed) };
+  }
+  const match = trimmed.match(
+    /github\.com[/:]([^/]+\/[^/]+?)(?:\.git)?\/pull\/(\d+)/
+  );
+  if (!match) {
+    throw new Error(
+      `Could not parse PR reference: ${pr}. Expected an integer or a github.com/<owner>/<repo>/pull/<n> URL.`
+    );
+  }
+  const [, sourceRepoPath, num] = match;
+  if (sourceRepoPath !== upstreamRepoPath) {
+    p.log.warn(
+      `PR URL points to ${sourceRepoPath}, but the upstream remote is ${upstreamRepoPath}. Continuing under the assumption you meant ${upstreamRepoPath} (gh fetch uses the upstream remote).`
+    );
+  }
+  return { number: Number(num), sourceRepoPath };
+}
+
+interface UpstreamPrMeta {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  state: string;
+  baseRefName: string;
+  headRefName: string;
+  author?: { login: string };
+  headRepositoryOwner?: { login: string };
+}
+
+async function fetchUpstreamPrMeta(
+  upstreamRepoPath: string,
+  prNumber: number,
+  cwd: string
+): Promise<UpstreamPrMeta> {
+  const fields =
+    'number,title,body,url,state,baseRefName,headRefName,author,headRepositoryOwner';
+  const result = await $({
+    cwd,
+    reject: false,
+  })`gh pr view ${prNumber} --repo ${upstreamRepoPath} --json ${fields}`;
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `Failed to read upstream PR #${prNumber} from ${upstreamRepoPath}: ${result.stderr.trim() || `exit ${result.exitCode}`}`
+    );
+  }
+  return JSON.parse(result.stdout) as UpstreamPrMeta;
+}
+
+/**
+ * Pull-request command: bring an upstream PR's commits into the private mirror
+ * for internal review. Fetches `pull/<n>/head` from the upstream remote onto a
+ * local branch (default `upstream-pr/<n>`), pushes to origin so the team can
+ * see it, and records a `pulledPrs` entry so `venfork sync <branch>` can
+ * later refresh it.
+ */
+export async function pullRequestCommand(
+  pr: string | undefined,
+  options: PullRequestOptions = {}
+): Promise<void> {
+  p.intro('🔀 Venfork Pull Request');
+
+  const isAuthenticated = await checkGhAuth();
+  if (!isAuthenticated) {
+    throw new AuthenticationError();
+  }
+
+  if (!pr) {
+    p.log.error('PR number or URL is required');
+    p.outro(
+      'Usage: venfork pull-request <pr-number-or-url> [--branch-name <override>] [--no-push]'
+    );
+    process.exit(1);
+  }
+
+  const s = p.spinner();
+  const repoDir = process.cwd();
+
+  try {
+    s.start('Resolving upstream remote');
+    const upstreamUrlResult = await $({
+      cwd: repoDir,
+      reject: false,
+    })`git remote get-url upstream`;
+    if (upstreamUrlResult.exitCode !== 0) {
+      throw new RemoteNotFoundError('upstream');
+    }
+    const upstreamRepoPath = parseRepoPath(upstreamUrlResult.stdout.trim());
+    if (!upstreamRepoPath) {
+      throw new Error(
+        `Could not parse upstream remote URL: ${upstreamUrlResult.stdout.trim()}`
+      );
+    }
+    s.stop(`Upstream: ${upstreamRepoPath}`);
+
+    const { number: prNumber } = resolvePullRequestArg(pr, upstreamRepoPath);
+    const localBranch = options.branchName ?? `upstream-pr/${prNumber}`;
+    const push = options.push !== false;
+
+    s.start(`Reading upstream PR #${prNumber} metadata`);
+    const meta = await fetchUpstreamPrMeta(upstreamRepoPath, prNumber, repoDir);
+    s.stop(`Read PR: ${meta.title} (${meta.state})`);
+
+    // Refuse to clobber an existing local branch unless the user opts in via
+    // a custom --branch-name. This prevents stomping on a previous review.
+    const existing = await $({
+      cwd: repoDir,
+      reject: false,
+    })`git rev-parse --verify ${localBranch}`;
+    if (existing.exitCode === 0 && !options.branchName) {
+      throw new Error(
+        `Local branch '${localBranch}' already exists. Pass --branch-name <override> to use a different name, or delete the existing branch first.`
+      );
+    }
+
+    s.start(`Fetching pull/${prNumber}/head from upstream`);
+    const fetchRefspec = `pull/${prNumber}/head:${localBranch}`;
+    const fetchResult = await $({
+      cwd: repoDir,
+      reject: false,
+    })`git fetch upstream ${fetchRefspec}`;
+    if (fetchResult.exitCode !== 0) {
+      throw new Error(
+        `git fetch upstream ${fetchRefspec} failed. The PR's head ref may have been removed by a deleted source branch. Stderr:\n${fetchResult.stderr.trim()}`
+      );
+    }
+    const headSha = (
+      await $({ cwd: repoDir })`git rev-parse ${localBranch}`
+    ).stdout.trim();
+    s.stop(`Fetched ${headSha.slice(0, 9)} → ${localBranch}`);
+
+    if (push) {
+      s.start(`Pushing ${localBranch} to origin`);
+      const pushResult = await $({
+        cwd: repoDir,
+        reject: false,
+      })`git push origin ${localBranch}`;
+      if (pushResult.exitCode !== 0) {
+        s.stop('Push failed');
+        p.log.warn(
+          `Could not push ${localBranch} to origin: ${pushResult.stderr.trim()}`
+        );
+        p.log.warn('The local branch is still available for review.');
+      } else {
+        s.stop(`Pushed ${localBranch} to origin`);
+      }
+    }
+
+    try {
+      await updateVenforkConfig(repoDir, {
+        pulledPrs: {
+          [localBranch]: {
+            upstreamPrNumber: prNumber,
+            upstreamPrUrl: meta.url,
+            head: headSha,
+            lastSyncedAt: new Date().toISOString(),
+          },
+        },
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      p.log.warn(
+        `Could not record pulledPrs entry: ${msg}. \`venfork sync ${localBranch}\` will fall back to convention-based resolution.`
+      );
+    }
+
+    const bodyPreview =
+      meta.body.length > 600
+        ? `${meta.body.slice(0, 600)}\n…(truncated)`
+        : meta.body || '(empty)';
+    const headRepo = meta.headRepositoryOwner?.login
+      ? `${meta.headRepositoryOwner.login}:${meta.headRefName}`
+      : meta.headRefName;
+    p.note(
+      [
+        `Title:  ${meta.title}`,
+        `Author: ${meta.author?.login ?? '(unknown)'}`,
+        `State:  ${meta.state}`,
+        `Base:   ${meta.baseRefName}`,
+        `Head:   ${headRepo}`,
+        `URL:    ${meta.url}`,
+        '',
+        bodyPreview,
+      ].join('\n'),
+      `Upstream PR #${prNumber}`
+    );
+
+    p.note(
+      [
+        `git checkout ${localBranch}`,
+        `# review locally; open an internal PR on the mirror if you want team review`,
+        `# refresh later with: venfork sync ${localBranch}`,
+      ].join('\n'),
+      'Next Steps'
+    );
+
+    p.outro('✨ Pull request imported!');
+  } catch (error) {
+    s.stop('Error occurred');
+    p.log.error(error instanceof Error ? error.message : String(error));
+    p.outro('❌ Pull request import failed');
     process.exit(1);
   }
 }
@@ -1678,10 +2258,18 @@ venfork schedule <status|set <cron>|disable>
   Manage scheduled sync config stored in venfork-config
   Set writes/removes ${SYNC_WORKFLOW_PATH} on the private mirror default branch
 
-venfork stage <branch>
+venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]
   Push branch to public fork for PR to upstream
   When schedule is enabled, strips internal workflow commit before public push
+  With --pr, also opens the upstream PR using the internal-review PR's body
+    (with <!-- venfork:internal -->...<!-- /venfork:internal --> blocks redacted)
   This is when your work becomes visible to the client
+
+venfork pull-request <pr-number-or-url> [--branch-name <name>] [--no-push]
+  Bring a third-party upstream PR into the mirror for internal review
+  Fetches pull/<n>/head from upstream into a new branch (default: upstream-pr/<n>)
+  Pushes the branch to origin so the team can see it
+  Refresh later with: venfork sync <branch>
 
 venfork workflows <status|allow|block|clear> [workflow-file ...]
   Configure workflow allowlist/blocklist policy in venfork-config`,
@@ -1708,10 +2296,13 @@ git checkout -b feature/new-thing
 git push origin feature/new-thing
 # Still private! Create internal PR for team review
 
-# After team approval, stage for upstream
-venfork stage feature/new-thing
-# NOW visible on public fork
-# Create PR: public fork → upstream`,
+# After team approval, stage for upstream and open the PR in one go
+venfork stage feature/new-thing --pr
+# NOW visible on public fork; upstream PR is opened with your internal review body
+
+# Bring a third-party upstream PR in for internal review
+venfork pull-request 1234
+# Refresh as the contributor pushes updates: venfork sync upstream-pr/1234`,
     'Example Workflow'
   );
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,17 +46,22 @@ async function pathExists(filePath: string): Promise<boolean> {
 }
 
 /**
- * `p.confirm` wrapper that returns `true` immediately when
- * `VENFORK_NONINTERACTIVE=1` is set in the environment. Lets scripts and
- * tests bypass interactive confirms without having to feed key presses
- * through stdin (clack's confirm reads keypresses, which doesn't work
- * cleanly with line-buffered piped input).
+ * `p.confirm` wrapper that can return `true` immediately when
+ * `VENFORK_NONINTERACTIVE=1` is set in the environment, but only for
+ * callers that explicitly opt into that behavior by passing
+ * `allowNonInteractive: true`. This lets scripts and tests bypass intended
+ * interactive confirms without turning every prompt into an implicit "yes"
+ * in CI/non-interactive environments.
  */
 async function confirmOrAutoYes(opts: {
   message: string;
   initialValue?: boolean;
+  allowNonInteractive?: boolean;
 }): Promise<boolean | symbol> {
-  if (process.env.VENFORK_NONINTERACTIVE === '1') {
+  if (
+    opts.allowNonInteractive === true &&
+    process.env.VENFORK_NONINTERACTIVE === '1'
+  ) {
     return true;
   }
   return p.confirm(opts);
@@ -1706,9 +1711,9 @@ async function findInternalPr(
 
 /**
  * Strips `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks and
- * appends a footer linking back to the internal review PR (only the team can
- * follow that link; the upstream maintainer sees only that there *was* an
- * internal review).
+ * appends a footer linking back to the internal review PR or issue (only the
+ * team can follow that link; the upstream maintainer sees only that there
+ * *was* an internal review).
  *
  * Iterates the strip until no markers remain, so nested marker pairs are
  * handled correctly. (The non-greedy `*?` matches the innermost pair on each
@@ -1716,7 +1721,8 @@ async function findInternalPr(
  */
 function translateInternalBody(
   body: string,
-  internalPrUrl: string | undefined
+  internalUrl: string | undefined,
+  kind: 'pr' | 'issue' = 'pr'
 ): string {
   let stripped = body;
   // Bounded loop guards against pathological input. 64 is way more nesting
@@ -1728,8 +1734,10 @@ function translateInternalBody(
     stripped = stripped.replace(VENFORK_INTERNAL_REDACTION_RE, '');
   }
   stripped = stripped.trim();
-  const footer = internalPrUrl
-    ? `\n\n> Upstreamed from internal review (${internalPrUrl}).`
+  const footer = internalUrl
+    ? kind === 'issue'
+      ? `\n\n> Upstreamed from internal issue (${internalUrl}).`
+      : `\n\n> Upstreamed from internal review (${internalUrl}).`
     : '';
   return `${stripped}${footer}`.trim();
 }
@@ -1739,12 +1747,17 @@ function translateInternalBody(
  * internal review PR was found. Lists the non-merge commits in
  * `upstream/<defaultBranch>..<branch>` so the upstream maintainer sees what
  * the change actually is, rather than a "please add a description" placeholder.
+ *
+ * Fetches `upstream/<defaultBranch>` first so the log works even when schedule
+ * is disabled and the ref may not exist locally yet.
  */
 async function buildSyntheticBody(
   branch: string,
   defaultBranch: string,
   cwd: string
 ): Promise<string> {
+  // Ensure the remote-tracking ref exists before running the log.
+  await $({ cwd, reject: false })`git fetch upstream ${defaultBranch}`;
   const log = await $({
     cwd,
     reject: false,
@@ -1851,7 +1864,7 @@ export async function stageCommand(
   if (!branch) {
     p.log.error('Branch name is required');
     p.outro(
-      'Usage: venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]'
+      'Usage: venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]. Run `venfork help` for the full list of supported options, including `--internal-pr <n>` and `--no-update-existing`.'
     );
     process.exit(1);
   }
@@ -1929,6 +1942,7 @@ export async function stageCommand(
         ? 'Push to public fork and open the upstream PR?'
         : 'Push to public fork?',
       initialValue: false,
+      allowNonInteractive: createPr,
     });
 
     if (p.isCancel(shouldStage)) {
@@ -2179,7 +2193,7 @@ export async function pullRequestCommand(
     })`git fetch upstream ${fetchRefspec}`;
     if (fetchResult.exitCode !== 0) {
       throw new Error(
-        `git fetch upstream ${fetchRefspec} failed. The PR's head ref may have been removed by a deleted source branch. Stderr:\n${fetchResult.stderr.trim()}`
+        `git fetch upstream ${fetchRefspec} failed. This can happen if the PR's source branch was deleted, or if the local branch already exists at a different commit (try deleting or renaming it first). Stderr:\n${fetchResult.stderr.trim()}`
       );
     }
     const headSha = (
@@ -2374,6 +2388,14 @@ export async function issueCommand(
     process.exit(1);
   }
 
+  if (action !== 'stage' && action !== 'pull') {
+    p.log.error(
+      `Unknown action '${action}'. Usage: venfork issue <stage|pull> <number-or-url> [--title <text>]`
+    );
+    p.outro('');
+    process.exit(1);
+  }
+
   const s = p.spinner();
   const repoDir = process.cwd();
 
@@ -2408,7 +2430,7 @@ export async function issueCommand(
       const internal = await readIssue(mirrorRepoPath, internalNumber, repoDir);
       s.stop(`Read: ${internal.title}`);
 
-      const translatedBody = translateInternalBody(internal.body, internal.url);
+      const translatedBody = translateInternalBody(internal.body, internal.url, 'issue');
       const upstreamTitle = options.title ?? internal.title;
 
       p.note(
@@ -2425,6 +2447,7 @@ export async function issueCommand(
       const ok = await confirmOrAutoYes({
         message: `Open the issue on ${upstreamRepoPath}?`,
         initialValue: false,
+        allowNonInteractive: true,
       });
       if (p.isCancel(ok) || !ok) {
         p.outro('Stage cancelled');
@@ -2489,6 +2512,7 @@ export async function issueCommand(
     const ok = await confirmOrAutoYes({
       message: `Open the issue on ${mirrorRepoPath}?`,
       initialValue: false,
+      allowNonInteractive: true,
     });
     if (p.isCancel(ok) || !ok) {
       p.outro('Pull cancelled');
@@ -2709,11 +2733,14 @@ venfork schedule <status|set <cron>|disable>
   Manage scheduled sync config stored in venfork-config
   Set writes/removes ${SYNC_WORKFLOW_PATH} on the private mirror default branch
 
-venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>]
+venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>] [--internal-pr <n>] [--no-update-existing]
   Push branch to public fork for PR to upstream
   When schedule is enabled, strips internal workflow commit before public push
   With --pr, also opens the upstream PR using the internal-review PR's body
     (with <!-- venfork:internal -->...<!-- /venfork:internal --> blocks redacted)
+  Options:
+  • --internal-pr <n>      Pin a specific internal review PR number (skips most-recent-open lookup)
+  • --no-update-existing   Do not update an already-open upstream PR body when staging
   This is when your work becomes visible to the client
 
 venfork pull-request <pr-number-or-url> [--branch-name <name>] [--no-push]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1385,12 +1385,125 @@ export async function workflowsCommand(
 }
 
 /**
+ * Read-only snapshot of the state needed to stage a branch. Computed before
+ * any user confirmation so the caller can show a preview, and reused for the
+ * actual push (`executeStagingPush`) and any follow-on work (e.g. opening an
+ * upstream PR in `shipCommand`).
+ */
+export interface StagingPlan {
+  branch: string;
+  publicUrl: string;
+  publicRepoPath: string;
+  upstreamUrl: string;
+  upstreamRepoPath: string;
+  upstreamDefaultBranch: string;
+  scheduleEnabled: boolean;
+  /** owner of the public fork — first half of `publicRepoPath`. */
+  publicOwner: string;
+}
+
+/**
+ * Resolves remotes, default branch, and schedule state for a staging push.
+ * Pure read; no network writes. Throws `BranchNotFoundError` /
+ * `RemoteNotFoundError` so callers can render a single failure path.
+ */
+async function planStaging(branch: string, cwd: string): Promise<StagingPlan> {
+  const branchCheck = await $({
+    cwd,
+    reject: false,
+  })`git rev-parse --verify ${branch}`;
+  if (branchCheck.exitCode !== 0) {
+    throw new BranchNotFoundError(branch);
+  }
+
+  const publicUrlResult = await $({
+    cwd,
+    reject: false,
+  })`git remote get-url public`;
+  if (publicUrlResult.exitCode !== 0) {
+    throw new RemoteNotFoundError('public');
+  }
+  const publicUrl = publicUrlResult.stdout.trim();
+  const publicRepoPath = parseRepoPath(publicUrl);
+  const publicOwner = publicRepoPath.split('/')[0] ?? '';
+
+  const upstreamUrlResult = await $({
+    cwd,
+    reject: false,
+  })`git remote get-url upstream`;
+  if (upstreamUrlResult.exitCode !== 0) {
+    throw new RemoteNotFoundError('upstream');
+  }
+  const upstreamUrl = upstreamUrlResult.stdout.trim();
+  const upstreamRepoPath = parseRepoPath(upstreamUrl);
+
+  const upstreamDefaultBranch = await getDefaultBranch('upstream');
+  const scheduleEnabled = await isScheduleEnabled(cwd);
+
+  return {
+    branch,
+    publicUrl,
+    publicRepoPath,
+    upstreamUrl,
+    upstreamRepoPath,
+    upstreamDefaultBranch,
+    scheduleEnabled,
+    publicOwner,
+  };
+}
+
+/**
+ * Pushes the branch to the public fork, stripping the internal workflow
+ * commit when scheduled sync is enabled. Returns the SHA pushed.
+ *
+ * The caller owns the spinner so consistent UI text appears in every
+ * command that stages (`stage`, `ship`).
+ */
+async function executeStagingPush(
+  plan: StagingPlan,
+  cwd: string,
+  s: ReturnType<typeof p.spinner>
+): Promise<string> {
+  if (plan.scheduleEnabled) {
+    await $({ cwd })`git fetch upstream`;
+    await $({ cwd })`git fetch origin`;
+    s.start('Preparing sanitized branch for public staging');
+    const stageHead = await buildPublicStageHeadWithoutWorkflowCommit(
+      plan.branch,
+      plan.upstreamDefaultBranch,
+      cwd
+    );
+    s.stop('Prepared sanitized branch');
+
+    s.start('Pushing sanitized branch to public fork');
+    if (await remoteBranchExists('public', plan.branch)) {
+      await $({
+        cwd,
+      })`git push public ${stageHead}:refs/heads/${plan.branch} --force-with-lease=refs/heads/${plan.branch}`;
+    } else {
+      await $({
+        cwd,
+      })`git push public ${stageHead}:refs/heads/${plan.branch}`;
+    }
+    s.stop('Push successful');
+    return stageHead;
+  }
+
+  s.start('Pushing to public fork');
+  await $({ cwd })`git push public ${plan.branch}`;
+  s.stop('Push successful');
+  const headResult = await $({
+    cwd,
+  })`git rev-parse ${plan.branch}`;
+  return headResult.stdout.trim();
+}
+
+/**
  * Stage command: Push branch to public fork for PR to upstream
  */
 export async function stageCommand(branch: string): Promise<void> {
   p.intro('📤 Venfork Stage');
 
-  // Check GitHub CLI authentication
   const isAuthenticated = await checkGhAuth();
   if (!isAuthenticated) {
     throw new AuthenticationError();
@@ -1403,43 +1516,20 @@ export async function stageCommand(branch: string): Promise<void> {
   }
 
   const s = p.spinner();
+  const repoDir = process.cwd();
 
   try {
-    // Step 1: Verify branch exists
     s.start('Verifying branch exists');
-    const branchCheck = await $({
-      reject: false,
-    })`git rev-parse --verify ${branch}`;
-    if (branchCheck.exitCode !== 0) {
-      throw new BranchNotFoundError(branch);
-    }
+    const plan = await planStaging(branch, repoDir);
     s.stop('Branch verified');
 
-    // Step 2: Get public fork URL
-    const publicUrlResult = await $({
-      reject: false,
-    })`git remote get-url public`;
-    if (publicUrlResult.exitCode !== 0) {
-      throw new RemoteNotFoundError('public');
-    }
-    const publicUrl = publicUrlResult.stdout.trim();
-    const publicRepoPath = parseRepoPath(publicUrl);
-
-    // Step 3: Get upstream URL for PR link
-    const upstreamUrlResult = await $({
-      reject: false,
-    })`git remote get-url upstream`;
-    const upstreamUrl = upstreamUrlResult.stdout.trim();
-    const upstreamRepoPath = parseRepoPath(upstreamUrl);
-
-    // Step 4: Confirm stage
     p.note(
-      `Branch '${branch}' will be pushed to your public fork.
+      `Branch '${plan.branch}' will be pushed to your public fork.
 This makes your work visible and ready for PR to upstream.
 
   From: Private vendor repo (current)
-  To:   ${publicUrl}
-  PR:   ${publicRepoPath} → ${upstreamRepoPath}`,
+  To:   ${plan.publicUrl}
+  PR:   ${plan.publicRepoPath} → ${plan.upstreamRepoPath}`,
       'Staging Details'
     );
 
@@ -1458,40 +1548,9 @@ This makes your work visible and ready for PR to upstream.
       process.exit(0);
     }
 
-    const repoDir = process.cwd();
+    await executeStagingPush(plan, repoDir, s);
 
-    // Step 5: Detect upstream default branch for staging + PR URL
-    const upstreamDefaultBranch = await getDefaultBranch('upstream');
-    const scheduleEnabled = await isScheduleEnabled(repoDir);
-
-    // Step 6: If schedule is enabled, strip the internal workflow commit before
-    // publishing. Otherwise keep normal direct branch push behavior.
-    if (scheduleEnabled) {
-      await $`git fetch upstream`;
-      await $`git fetch origin`;
-      s.start('Preparing sanitized branch for public staging');
-      const stageHead = await buildPublicStageHeadWithoutWorkflowCommit(
-        branch,
-        upstreamDefaultBranch,
-        repoDir
-      );
-      s.stop('Prepared sanitized branch');
-
-      s.start('Pushing sanitized branch to public fork');
-      if (await remoteBranchExists('public', branch)) {
-        await $`git push public ${stageHead}:refs/heads/${branch} --force-with-lease=refs/heads/${branch}`;
-      } else {
-        await $`git push public ${stageHead}:refs/heads/${branch}`;
-      }
-      s.stop('Push successful');
-    } else {
-      s.start('Pushing to public fork');
-      await $`git push public ${branch}`;
-      s.stop('Push successful');
-    }
-
-    // Step 7: Show PR creation link
-    const prUrl = `https://github.com/${upstreamRepoPath}/compare/${upstreamDefaultBranch}...${publicRepoPath.split('/')[0]}:${branch}?expand=1`;
+    const prUrl = `https://github.com/${plan.upstreamRepoPath}/compare/${plan.upstreamDefaultBranch}...${plan.publicOwner}:${plan.branch}?expand=1`;
 
     p.note(
       `Your branch is now on the public fork!\n\nCreate a pull request to upstream:\n  ${prUrl}`,

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1131,10 +1131,12 @@ async function syncPulledPr(
     p.log.warn(
       `Could not push ${branch} to origin: ${pushResult.stderr.trim()}`
     );
-    p.log.warn('Local branch is updated; the mirror copy was not.');
-  } else {
-    s.stop(`Pushed ${branch} to origin`);
+    p.log.warn(
+      'Local branch is updated; the mirror copy was not. Skipping pulledPrs config update — the recorded head/lastSyncedAt would not match the mirror.'
+    );
+    return;
   }
+  s.stop(`Pushed ${branch} to origin`);
 
   try {
     await updateVenforkConfig(cwd, {
@@ -1655,8 +1657,84 @@ interface InternalPrInfo {
   body: string;
 }
 
-const VENFORK_INTERNAL_REDACTION_RE =
-  /<!--\s*venfork:internal\s*-->[\s\S]*?<!--\s*\/venfork:internal\s*-->/;
+const VENFORK_INTERNAL_OPEN_RE = /<!--\s*venfork:internal\s*-->/g;
+const VENFORK_INTERNAL_CLOSE_RE = /<!--\s*\/venfork:internal\s*-->/g;
+
+interface RedactionMarker {
+  type: 'open' | 'close';
+  start: number;
+  end: number;
+}
+
+/**
+ * Removes properly-nested `<!-- venfork:internal -->...<!-- /venfork:internal -->`
+ * blocks from `body`. Walks markers in document order and tracks depth, so
+ * nested pairs collapse correctly: every char between the outermost open and
+ * its matching close is dropped (including any inner pairs).
+ *
+ * Edge cases:
+ *  - Unmatched close marker: dropped, surrounding content preserved.
+ *  - Unmatched open marker: content from that open to end-of-input is
+ *    dropped (defensive — a missing close shouldn't leak intended-private
+ *    content upstream).
+ *  - Whitespace inside the markers is tolerated (`<!-- venfork:internal -->`
+ *    and `<!--venfork:internal-->` both match).
+ *
+ * @internal Exported for unit testing; not part of the public API.
+ */
+export function stripInternalBlocks(body: string): string {
+  const markers: RedactionMarker[] = [];
+  // Reset lastIndex on the global regexes — they're module-scoped and would
+  // otherwise carry state across calls.
+  VENFORK_INTERNAL_OPEN_RE.lastIndex = 0;
+  VENFORK_INTERNAL_CLOSE_RE.lastIndex = 0;
+
+  for (
+    let m = VENFORK_INTERNAL_OPEN_RE.exec(body);
+    m !== null;
+    m = VENFORK_INTERNAL_OPEN_RE.exec(body)
+  ) {
+    markers.push({ type: 'open', start: m.index, end: m.index + m[0].length });
+  }
+  for (
+    let m = VENFORK_INTERNAL_CLOSE_RE.exec(body);
+    m !== null;
+    m = VENFORK_INTERNAL_CLOSE_RE.exec(body)
+  ) {
+    markers.push({ type: 'close', start: m.index, end: m.index + m[0].length });
+  }
+  markers.sort((a, b) => a.start - b.start);
+
+  let result = '';
+  let cursor = 0;
+  let depth = 0;
+  for (const marker of markers) {
+    if (marker.type === 'open') {
+      if (depth === 0) {
+        // Surfacing into a new redacted block — emit content up to here.
+        result += body.slice(cursor, marker.start);
+      }
+      depth += 1;
+      cursor = marker.end;
+      continue;
+    }
+    if (depth > 0) {
+      depth -= 1;
+      cursor = marker.end;
+    } else {
+      // Unmatched close marker. Keep the content before it; drop the
+      // marker itself.
+      result += body.slice(cursor, marker.start);
+      cursor = marker.end;
+    }
+  }
+  if (depth === 0) {
+    result += body.slice(cursor);
+  }
+  // depth > 0 here means an unclosed open marker — content from the
+  // unmatched open to end-of-input is intentionally dropped.
+  return result;
+}
 
 /**
  * Looks up the most relevant internal PR for `branch` on the private mirror.
@@ -1710,30 +1788,18 @@ async function findInternalPr(
 }
 
 /**
- * Strips `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks and
- * appends a footer linking back to the internal review PR or issue (only the
- * team can follow that link; the upstream maintainer sees only that there
- * *was* an internal review).
- *
- * Iterates the strip until no markers remain, so nested marker pairs are
- * handled correctly. (The non-greedy `*?` matches the innermost pair on each
- * pass; outer pairs become matchable once their inner content is stripped.)
+ * Strips `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks via
+ * a depth-tracking pass (see `stripInternalBlocks`) and appends a footer
+ * linking back to the internal review PR or issue. Only the team can follow
+ * that link; the upstream maintainer sees only that there *was* an internal
+ * review.
  */
 function translateInternalBody(
   body: string,
   internalUrl: string | undefined,
   kind: 'pr' | 'issue' = 'pr'
 ): string {
-  let stripped = body;
-  // Bounded loop guards against pathological input. 64 is way more nesting
-  // than any reasonable PR description would have.
-  for (let i = 0; i < 64; i += 1) {
-    if (!VENFORK_INTERNAL_REDACTION_RE.test(stripped)) {
-      break;
-    }
-    stripped = stripped.replace(VENFORK_INTERNAL_REDACTION_RE, '');
-  }
-  stripped = stripped.trim();
+  const stripped = stripInternalBlocks(body).trim();
   const footer = internalUrl
     ? kind === 'issue'
       ? `\n\n> Upstreamed from internal issue (${internalUrl}).`
@@ -2027,7 +2093,10 @@ export async function stageCommand(
       }
     }
 
-    const prUrl = `https://github.com/${plan.upstreamRepoPath}/compare/${plan.upstreamDefaultBranch}...${plan.publicOwner}:${plan.branch}?expand=1`;
+    // Use the resolved baseBranch (which respects --base) so the compare URL
+    // points at the same base the user asked for, even if --pr wasn't set
+    // or `gh pr create` failed earlier.
+    const prUrl = `https://github.com/${plan.upstreamRepoPath}/compare/${baseBranch}...${plan.publicOwner}:${plan.branch}?expand=1`;
 
     if (createPr && upstreamPrUrl) {
       const lines = [`Upstream PR: ${upstreamPrUrl}`];

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1630,6 +1630,17 @@ export interface StageOptions {
   title?: string;
   /** Override the upstream base branch; default is upstream's default branch. */
   base?: string;
+  /**
+   * Pin the internal review PR by number instead of letting `findInternalPr`
+   * pick the most recent one for the branch.
+   */
+  internalPrNumber?: number;
+  /**
+   * When true, *don't* update an existing upstream PR's body if one is found
+   * for the same head/base. Default behaviour (false) re-syncs the body via
+   * `gh pr edit` so addressing internal feedback re-publishes upstream.
+   */
+  noUpdateExisting?: boolean;
 }
 
 interface InternalPrInfo {
@@ -1640,19 +1651,35 @@ interface InternalPrInfo {
 }
 
 const VENFORK_INTERNAL_REDACTION_RE =
-  /<!--\s*venfork:internal\s*-->[\s\S]*?<!--\s*\/venfork:internal\s*-->/g;
+  /<!--\s*venfork:internal\s*-->[\s\S]*?<!--\s*\/venfork:internal\s*-->/;
 
 /**
  * Looks up the most relevant internal PR for `branch` on the private mirror.
- * Prefers the most recent open PR; falls back to the most recent of any state.
- * Returns null if none exists or the lookup fails (network/rate limit) — the
- * caller falls back to a synthetic body.
+ * When `pinnedNumber` is set, fetches that exact PR via `gh pr view` (skips
+ * the list lookup). Otherwise prefers the most recent open PR, then the most
+ * recent of any state. Returns null if none exists or the lookup fails — the
+ * caller falls back to a generated synthetic body.
  */
 async function findInternalPr(
   mirrorRepoPath: string,
   branch: string,
-  cwd: string
+  cwd: string,
+  pinnedNumber?: number
 ): Promise<InternalPrInfo | null> {
+  if (pinnedNumber !== undefined) {
+    const result = await $({
+      cwd,
+      reject: false,
+    })`gh pr view ${pinnedNumber} --repo ${mirrorRepoPath} --json number,url,title,body`;
+    if (result.exitCode !== 0) {
+      return null;
+    }
+    try {
+      return JSON.parse(result.stdout) as InternalPrInfo;
+    } catch {
+      return null;
+    }
+  }
   // Prefer an open PR; if none, take the most recent of any state.
   // Pass each flag/value as a separate execa interpolation — passing
   // `--state open` as a single string makes execa treat it as one arg
@@ -1682,12 +1709,25 @@ async function findInternalPr(
  * appends a footer linking back to the internal review PR (only the team can
  * follow that link; the upstream maintainer sees only that there *was* an
  * internal review).
+ *
+ * Iterates the strip until no markers remain, so nested marker pairs are
+ * handled correctly. (The non-greedy `*?` matches the innermost pair on each
+ * pass; outer pairs become matchable once their inner content is stripped.)
  */
 function translateInternalBody(
   body: string,
   internalPrUrl: string | undefined
 ): string {
-  const stripped = body.replace(VENFORK_INTERNAL_REDACTION_RE, '').trim();
+  let stripped = body;
+  // Bounded loop guards against pathological input. 64 is way more nesting
+  // than any reasonable PR description would have.
+  for (let i = 0; i < 64; i += 1) {
+    if (!VENFORK_INTERNAL_REDACTION_RE.test(stripped)) {
+      break;
+    }
+    stripped = stripped.replace(VENFORK_INTERNAL_REDACTION_RE, '');
+  }
+  stripped = stripped.trim();
   const footer = internalPrUrl
     ? `\n\n> Upstreamed from internal review (${internalPrUrl}).`
     : '';
@@ -1695,14 +1735,41 @@ function translateInternalBody(
 }
 
 /**
- * Build the body and title for the upstream PR. Falls back to a synthetic body
- * keyed off the branch name when there's no internal PR to translate.
+ * Generates a synthetic upstream PR body from the branch's commit log when no
+ * internal review PR was found. Lists the non-merge commits in
+ * `upstream/<defaultBranch>..<branch>` so the upstream maintainer sees what
+ * the change actually is, rather than a "please add a description" placeholder.
  */
-function buildUpstreamPrPayload(
+async function buildSyntheticBody(
+  branch: string,
+  defaultBranch: string,
+  cwd: string
+): Promise<string> {
+  const log = await $({
+    cwd,
+    reject: false,
+  })`git log --oneline --no-merges upstream/${defaultBranch}..${branch}`;
+  if (log.exitCode !== 0 || !log.stdout.trim()) {
+    return 'Staged from a private mirror. No internal review PR was open at stage time.';
+  }
+  const lines = log.stdout
+    .trim()
+    .split('\n')
+    .map((line) => `- ${line}`)
+    .join('\n');
+  return `Staged from a private mirror. Commits in this branch:\n\n${lines}\n\n_(No internal review PR was found at stage time.)_`;
+}
+
+/**
+ * Build the body and title for the upstream PR. Falls back to a generated
+ * commit-summary body when there's no internal PR to translate.
+ */
+async function buildUpstreamPrPayload(
   branch: string,
   internal: InternalPrInfo | null,
-  override: { title?: string; body?: string }
-): { title: string; body: string } {
+  override: { title?: string; body?: string },
+  context: { defaultBranch: string; cwd: string }
+): Promise<{ title: string; body: string }> {
   if (internal) {
     return {
       title: override.title ?? internal.title,
@@ -1713,7 +1780,7 @@ function buildUpstreamPrPayload(
     title: override.title ?? branch,
     body:
       override.body ??
-      `Branch staged from a venfork-managed private mirror. No internal review PR found for \`${branch}\`; please add a description.`,
+      (await buildSyntheticBody(branch, context.defaultBranch, context.cwd)),
   };
 }
 
@@ -1809,11 +1876,19 @@ export async function stageCommand(
       s.start('Looking up internal review PR');
       const mirrorRepoPath = await findMirrorRepoPath(repoDir);
       if (mirrorRepoPath) {
-        internalPr = await findInternalPr(mirrorRepoPath, plan.branch, repoDir);
+        internalPr = await findInternalPr(
+          mirrorRepoPath,
+          plan.branch,
+          repoDir,
+          options.internalPrNumber
+        );
       }
-      const payload = buildUpstreamPrPayload(plan.branch, internalPr, {
-        title: options.title,
-      });
+      const payload = await buildUpstreamPrPayload(
+        plan.branch,
+        internalPr,
+        { title: options.title },
+        { defaultBranch: plan.upstreamDefaultBranch, cwd: repoDir }
+      );
       prTitle = payload.title;
       translatedBody = payload.body;
       s.stop(
@@ -1898,6 +1973,26 @@ export async function stageCommand(
           'Staging succeeded; you can retry the PR manually with `gh pr create`.'
         );
       }
+
+      // Refresh the existing upstream PR's body from the (possibly updated)
+      // internal review. Default behaviour; opt out with --no-update-existing
+      // if the user wants the upstream body frozen at first-stage time.
+      if (alreadyExisted && upstreamPrUrl && !options.noUpdateExisting) {
+        s.start('Updating existing upstream PR body');
+        const editResult = await $({
+          cwd: repoDir,
+          reject: false,
+          input: translatedBody,
+        })`gh pr edit ${upstreamPrUrl} --body-file -`;
+        if (editResult.exitCode === 0) {
+          s.stop('Updated upstream PR body');
+        } else {
+          s.stop('Could not update upstream PR body');
+          p.log.warn(
+            editResult.stderr.trim() || `gh pr edit exit ${editResult.exitCode}`
+          );
+        }
+      }
     }
 
     if (createPr && upstreamPrUrl) {
@@ -1972,8 +2067,8 @@ function resolvePullRequestArg(
   }
   const [, sourceRepoPath, num] = match;
   if (sourceRepoPath !== upstreamRepoPath) {
-    p.log.warn(
-      `PR URL points to ${sourceRepoPath}, but the upstream remote is ${upstreamRepoPath}. Continuing under the assumption you meant ${upstreamRepoPath} (gh fetch uses the upstream remote).`
+    throw new Error(
+      `Refused to use PR URL ${pr}: it points to ${sourceRepoPath}, but the upstream remote is ${upstreamRepoPath}. If this is intentional, pass the PR number directly (\`venfork pull-request ${num}\`).`
     );
   }
   return { number: Number(num), sourceRepoPath };
@@ -2092,6 +2187,7 @@ export async function pullRequestCommand(
     ).stdout.trim();
     s.stop(`Fetched ${headSha.slice(0, 9)} → ${localBranch}`);
 
+    let pushSucceeded = !push; // If push is disabled, treat as "no push needed".
     if (push) {
       s.start(`Pushing ${localBranch} to origin`);
       const pushResult = await $({
@@ -2103,10 +2199,21 @@ export async function pullRequestCommand(
         p.log.warn(
           `Could not push ${localBranch} to origin: ${pushResult.stderr.trim()}`
         );
-        p.log.warn('The local branch is still available for review.');
+        p.log.warn(
+          'The local branch is still available for review, but no pulledPrs entry was recorded — `venfork sync` will not know how to refresh it until the next successful push.'
+        );
       } else {
         s.stop(`Pushed ${localBranch} to origin`);
+        pushSucceeded = true;
       }
+    }
+
+    if (!pushSucceeded) {
+      // Skip the linkage record so the user doesn't think the mirror has the
+      // branch. The local branch remains, so they can `git push origin
+      // <branch>` themselves and re-run `venfork pull-request` if desired.
+      p.outro('✨ Pull request fetched locally (mirror push failed)');
+      return;
     }
 
     try {
@@ -2234,8 +2341,8 @@ function resolveIssueArg(
   }
   const [, sourceRepoPath, num] = match;
   if (sourceRepoPath !== expectedRepoPath) {
-    p.log.warn(
-      `Issue URL points to ${sourceRepoPath}, but the expected repo is ${expectedRepoPath}. Continuing under that assumption.`
+    throw new Error(
+      `Refused to use issue URL ${target}: it points to ${sourceRepoPath}, but the expected repo is ${expectedRepoPath}. If this is intentional, pass the issue number directly.`
     );
   }
   return { number: Number(num) };
@@ -2473,6 +2580,73 @@ export async function statusCommand(): Promise<void> {
   ];
 
   p.note(statusLines.join('\n'), 'Repository Status');
+
+  // Surface PR/issue linkages from venfork-config (best-effort — quietly skip
+  // if the branch is missing or the read fails).
+  if (isSetupComplete) {
+    try {
+      const cfg = await readVenforkConfigFromRepo(process.cwd());
+      const linkageBlocks: string[] = [];
+
+      const formatDate = (iso: string): string => {
+        try {
+          return new Date(iso).toISOString().slice(0, 10);
+        } catch {
+          return iso;
+        }
+      };
+
+      const ship = cfg?.shippedBranches ?? {};
+      if (Object.keys(ship).length > 0) {
+        const lines = Object.entries(ship)
+          .map(
+            ([branch, entry]) =>
+              `  ${branch} → ${entry.upstreamPrUrl} (${formatDate(entry.shippedAt)})`
+          )
+          .join('\n');
+        linkageBlocks.push(`Shipped branches:\n${lines}`);
+      }
+
+      const pulled = cfg?.pulledPrs ?? {};
+      if (Object.keys(pulled).length > 0) {
+        const lines = Object.entries(pulled)
+          .map(
+            ([branch, entry]) =>
+              `  ${branch} → ${entry.upstreamPrUrl} (last sync ${formatDate(entry.lastSyncedAt)})`
+          )
+          .join('\n');
+        linkageBlocks.push(`Pulled PRs:\n${lines}`);
+      }
+
+      const shippedIssues = cfg?.shippedIssues ?? {};
+      if (Object.keys(shippedIssues).length > 0) {
+        const lines = Object.entries(shippedIssues)
+          .map(
+            ([, entry]) =>
+              `  #${entry.internalIssueNumber} → ${entry.upstreamIssueUrl} (${formatDate(entry.shippedAt)})`
+          )
+          .join('\n');
+        linkageBlocks.push(`Shipped issues:\n${lines}`);
+      }
+
+      const pulledIssues = cfg?.pulledIssues ?? {};
+      if (Object.keys(pulledIssues).length > 0) {
+        const lines = Object.entries(pulledIssues)
+          .map(
+            ([, entry]) =>
+              `  #${entry.internalIssueNumber} ← ${entry.upstreamIssueUrl} (${formatDate(entry.pulledAt)})`
+          )
+          .join('\n');
+        linkageBlocks.push(`Pulled issues:\n${lines}`);
+      }
+
+      if (linkageBlocks.length > 0) {
+        p.note(linkageBlocks.join('\n\n'), 'Linkages');
+      }
+    } catch {
+      // Best-effort; status should never fail because of a config read.
+    }
+  }
 
   // Show appropriate outro
   if (isSetupComplete) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -45,6 +45,23 @@ async function pathExists(filePath: string): Promise<boolean> {
   }
 }
 
+/**
+ * `p.confirm` wrapper that returns `true` immediately when
+ * `VENFORK_NONINTERACTIVE=1` is set in the environment. Lets scripts and
+ * tests bypass interactive confirms without having to feed key presses
+ * through stdin (clack's confirm reads keypresses, which doesn't work
+ * cleanly with line-buffered piped input).
+ */
+async function confirmOrAutoYes(opts: {
+  message: string;
+  initialValue?: boolean;
+}): Promise<boolean | symbol> {
+  if (process.env.VENFORK_NONINTERACTIVE === '1') {
+    return true;
+  }
+  return p.confirm(opts);
+}
+
 const SYNC_WORKFLOW_PATH = getSyncWorkflowPath();
 const WORKFLOW_COMMIT_MESSAGE =
   'chore: add/update scheduled sync workflow (venfork)';
@@ -1829,7 +1846,7 @@ export async function stageCommand(
       p.note(previewBody || '(empty)', 'Upstream PR body preview');
     }
 
-    const shouldStage = await p.confirm({
+    const shouldStage = await confirmOrAutoYes({
       message: createPr
         ? 'Push to public fork and open the upstream PR?'
         : 'Push to public fork?',
@@ -2295,7 +2312,7 @@ export async function issueCommand(
       );
       p.note(translatedBody || '(empty)', 'Upstream issue body preview');
 
-      const ok = await p.confirm({
+      const ok = await confirmOrAutoYes({
         message: `Open the issue on ${upstreamRepoPath}?`,
         initialValue: false,
       });
@@ -2359,7 +2376,7 @@ export async function issueCommand(
     );
     p.note(internalBody, 'Internal issue body preview');
 
-    const ok = await p.confirm({
+    const ok = await confirmOrAutoYes({
       message: `Open the issue on ${mirrorRepoPath}?`,
       initialValue: false,
     });

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2201,7 +2201,7 @@ export async function pullRequestCommand(
     ).stdout.trim();
     s.stop(`Fetched ${headSha.slice(0, 9)} → ${localBranch}`);
 
-    let pushSucceeded = !push; // If push is disabled, treat as "no push needed".
+    let pushedToMirror = false;
     if (push) {
       s.start(`Pushing ${localBranch} to origin`);
       const pushResult = await $({
@@ -2218,15 +2218,24 @@ export async function pullRequestCommand(
         );
       } else {
         s.stop(`Pushed ${localBranch} to origin`);
-        pushSucceeded = true;
+        pushedToMirror = true;
       }
     }
 
-    if (!pushSucceeded) {
-      // Skip the linkage record so the user doesn't think the mirror has the
-      // branch. The local branch remains, so they can `git push origin
-      // <branch>` themselves and re-run `venfork pull-request` if desired.
-      p.outro('✨ Pull request fetched locally (mirror push failed)');
+    if (!pushedToMirror) {
+      // Two paths reach here:
+      // 1. Push failed: warned above, branch is local-only.
+      // 2. --no-push: user asked us not to push; treat the branch as
+      //    local-only too. In both cases the mirror does not have the
+      //    branch, so we skip the pulledPrs record. Otherwise a later
+      //    `venfork sync <branch>` would push the branch to the mirror —
+      //    surprising for --no-push users (who explicitly opted out of
+      //    mirror state) and misleading for the failure case (the mirror
+      //    is out of sync with what we recorded).
+      const reason = push
+        ? 'mirror push failed'
+        : '--no-push set, branch is local-only';
+      p.outro(`✨ Pull request fetched locally (${reason})`);
       return;
     }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2430,7 +2430,11 @@ export async function issueCommand(
       const internal = await readIssue(mirrorRepoPath, internalNumber, repoDir);
       s.stop(`Read: ${internal.title}`);
 
-      const translatedBody = translateInternalBody(internal.body, internal.url, 'issue');
+      const translatedBody = translateInternalBody(
+        internal.body,
+        internal.url,
+        'issue'
+      );
       const upstreamTitle = options.title ?? internal.title;
 
       p.note(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1654,11 +1654,14 @@ async function findInternalPr(
   cwd: string
 ): Promise<InternalPrInfo | null> {
   // Prefer an open PR; if none, take the most recent of any state.
-  for (const stateFlag of ['--state open', '--state all']) {
+  // Pass each flag/value as a separate execa interpolation — passing
+  // `--state open` as a single string makes execa treat it as one arg
+  // and gh silently filters wrong (returns zero results).
+  for (const state of ['open', 'all'] as const) {
     const result = await $({
       cwd,
       reject: false,
-    })`gh pr list --repo ${mirrorRepoPath} --head ${branch} ${stateFlag} --json number,url,title,body --limit 1`;
+    })`gh pr list --repo ${mirrorRepoPath} --head ${branch} --state ${state} --json number,url,title,body --limit 1`;
     if (result.exitCode !== 0) {
       return null;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -213,12 +213,20 @@ function normalizeShippedBranch(value: unknown): ShippedBranch | null {
   return out;
 }
 
+/**
+ * GitHub PR / issue numbers are always positive integers. Reject anything
+ * else so a hand-edited config with garbage numbers (negatives, floats, NaN)
+ * doesn't leak into runtime.
+ */
+function isPositiveInt(n: unknown): n is number {
+  return typeof n === 'number' && Number.isInteger(n) && n > 0;
+}
+
 function normalizePulledPr(value: unknown): PulledPr | null {
   if (!value || typeof value !== 'object') return null;
   const v = value as Partial<PulledPr>;
   if (
-    typeof v.upstreamPrNumber !== 'number' ||
-    !Number.isFinite(v.upstreamPrNumber) ||
+    !isPositiveInt(v.upstreamPrNumber) ||
     typeof v.upstreamPrUrl !== 'string' ||
     !v.upstreamPrUrl.trim() ||
     typeof v.head !== 'string' ||
@@ -240,12 +248,10 @@ function normalizeShippedIssue(value: unknown): ShippedIssue | null {
   if (!value || typeof value !== 'object') return null;
   const v = value as Partial<ShippedIssue>;
   if (
-    typeof v.internalIssueNumber !== 'number' ||
-    !Number.isFinite(v.internalIssueNumber) ||
+    !isPositiveInt(v.internalIssueNumber) ||
     typeof v.internalIssueUrl !== 'string' ||
     !v.internalIssueUrl.trim() ||
-    typeof v.upstreamIssueNumber !== 'number' ||
-    !Number.isFinite(v.upstreamIssueNumber) ||
+    !isPositiveInt(v.upstreamIssueNumber) ||
     typeof v.upstreamIssueUrl !== 'string' ||
     !v.upstreamIssueUrl.trim() ||
     typeof v.shippedAt !== 'string' ||
@@ -266,12 +272,10 @@ function normalizePulledIssue(value: unknown): PulledIssue | null {
   if (!value || typeof value !== 'object') return null;
   const v = value as Partial<PulledIssue>;
   if (
-    typeof v.upstreamIssueNumber !== 'number' ||
-    !Number.isFinite(v.upstreamIssueNumber) ||
+    !isPositiveInt(v.upstreamIssueNumber) ||
     typeof v.upstreamIssueUrl !== 'string' ||
     !v.upstreamIssueUrl.trim() ||
-    typeof v.internalIssueNumber !== 'number' ||
-    !Number.isFinite(v.internalIssueNumber) ||
+    !isPositiveInt(v.internalIssueNumber) ||
     typeof v.internalIssueUrl !== 'string' ||
     !v.internalIssueUrl.trim() ||
     typeof v.pulledAt !== 'string' ||

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,8 +6,8 @@ import { $ } from 'execa';
 import { parseRepoPath } from './utils.js';
 
 /**
- * Record kept by `venfork ship` linking an internal review PR (on the private
- * mirror) to the upstream PR it was promoted to.
+ * Record kept by `venfork stage --pr` linking an internal review PR (on the
+ * private mirror) to the upstream PR it was promoted to.
  */
 export interface ShippedBranch {
   upstreamPrUrl: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,10 +60,7 @@ const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
 export type VenforkConfigPatch = Omit<
   Partial<VenforkConfig>,
-  | 'enabledWorkflows'
-  | 'disabledWorkflows'
-  | 'shippedBranches'
-  | 'pulledPrs'
+  'enabledWorkflows' | 'disabledWorkflows' | 'shippedBranches' | 'pulledPrs'
 > & {
   enabledWorkflows?: string[] | null;
   disabledWorkflows?: string[] | null;
@@ -254,10 +251,7 @@ function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
     delete normalized.shippedBranches;
   }
 
-  const pulledPrs = normalizeBranchMap(
-    normalized.pulledPrs,
-    normalizePulledPr
-  );
+  const pulledPrs = normalizeBranchMap(normalized.pulledPrs, normalizePulledPr);
   if (pulledPrs) {
     normalized.pulledPrs = pulledPrs;
   } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -157,9 +157,29 @@ async function writeConfigBranch(
 
     const remoteResult = await $({ cwd: repoDir })`git remote get-url origin`;
     const originUrl = remoteResult.stdout.trim();
-    await $({
+    // Read the current SHA of the config branch (if it exists) so we can pass
+    // an explicit lease — the bare `--force-with-lease` flag relies on a
+    // remote-tracking ref, which doesn't exist in this fresh tempDir.
+    // First-time writes have no upstream to lease against; falling back to a
+    // plain push is safe (no concurrent writers can exist when the branch
+    // doesn't yet exist).
+    const lsRemote = await $({
       cwd: tempDir,
-    })`git push ${originUrl} ${CONFIG_BRANCH}:${CONFIG_BRANCH} --force`;
+      reject: false,
+    })`git ls-remote ${originUrl} ${CONFIG_BRANCH}`;
+    const expectedSha =
+      lsRemote.exitCode === 0
+        ? (lsRemote.stdout.trim().split(/\s+/)[0] ?? '')
+        : '';
+    if (expectedSha) {
+      await $({
+        cwd: tempDir,
+      })`git push ${originUrl} ${CONFIG_BRANCH}:${CONFIG_BRANCH} --force-with-lease=${CONFIG_BRANCH}:${expectedSha}`;
+    } else {
+      await $({
+        cwd: tempDir,
+      })`git push ${originUrl} ${CONFIG_BRANCH}:${CONFIG_BRANCH}`;
+    }
   } finally {
     try {
       await rm(tempDir, { recursive: true, force: true });

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,10 +133,21 @@ export async function createConfigBranch(
   await writeConfigBranch(repoDir, config, 'Initialize venfork configuration');
 }
 
+/**
+ * Detects a `git push --force-with-lease` rejection due to upstream having
+ * moved since we read it. Distinguishes from auth/network failures (which
+ * should NOT trigger a config-write retry).
+ */
+function isLeaseFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err ?? '');
+  return /stale info/i.test(msg) || /\[rejected\][^\n]*stale/i.test(msg);
+}
+
 async function writeConfigBranch(
   repoDir: string,
   config: VenforkConfig,
-  commitMessage: string
+  commitMessage: string,
+  options: { expectedSha?: string } = {}
 ): Promise<void> {
   const uniqueId = randomBytes(8).toString('hex');
   const tempDir = path.join(os.tmpdir(), `venfork-config-${uniqueId}`);
@@ -157,25 +168,30 @@ async function writeConfigBranch(
 
     const remoteResult = await $({ cwd: repoDir })`git remote get-url origin`;
     const originUrl = remoteResult.stdout.trim();
-    // Read the current SHA of the config branch (if it exists) so we can pass
-    // an explicit lease — the bare `--force-with-lease` flag relies on a
-    // remote-tracking ref, which doesn't exist in this fresh tempDir.
-    // First-time writes have no upstream to lease against; falling back to a
-    // plain push is safe (no concurrent writers can exist when the branch
-    // doesn't yet exist).
-    const lsRemote = await $({
-      cwd: tempDir,
-      reject: false,
-    })`git ls-remote ${originUrl} ${CONFIG_BRANCH}`;
-    const expectedSha =
-      lsRemote.exitCode === 0
-        ? (lsRemote.stdout.trim().split(/\s+/)[0] ?? '')
-        : '';
+
+    // Caller-supplied lease wins — it's the SHA that was actually read,
+    // which is the only correct lease (a fresh ls-remote here would race
+    // with a concurrent writer who pushed between our read and our push).
+    // Fall back to ls-remote when no SHA is supplied, for first-time writes
+    // (`createConfigBranch`) and any callers that haven't been updated.
+    let expectedSha = options.expectedSha ?? '';
+    if (!expectedSha) {
+      const lsRemote = await $({
+        cwd: tempDir,
+        reject: false,
+      })`git ls-remote ${originUrl} ${CONFIG_BRANCH}`;
+      expectedSha =
+        lsRemote.exitCode === 0
+          ? (lsRemote.stdout.trim().split(/\s+/)[0] ?? '')
+          : '';
+    }
     if (expectedSha) {
       await $({
         cwd: tempDir,
       })`git push ${originUrl} ${CONFIG_BRANCH}:${CONFIG_BRANCH} --force-with-lease=${CONFIG_BRANCH}:${expectedSha}`;
     } else {
+      // First-time write: no upstream to lease against; concurrent writers
+      // can't exist yet because the branch doesn't yet exist.
       await $({
         cwd: tempDir,
       })`git push ${originUrl} ${CONFIG_BRANCH}:${CONFIG_BRANCH}`;
@@ -437,16 +453,35 @@ export async function fetchVenforkConfig(
 }
 
 /**
- * Reads venfork configuration from the local repo's orphan `venfork-config` branch.
+ * Atomically reads the config content + the SHA of the commit it came from
+ * by running fetch once and resolving both `FETCH_HEAD` (for the SHA) and
+ * `FETCH_HEAD:<config>` (for the content) against that single fetch. Returns
+ * null if the branch doesn't exist or the content is unreadable.
+ *
+ * Capturing the SHA here is what lets `updateVenforkConfig` push back with
+ * an explicit `--force-with-lease=<branch>:<sha>` against the *exact* SHA
+ * we read from — the only lease that's safe under concurrent writers.
  */
-export async function readVenforkConfigFromRepo(
+async function fetchConfigContentAndSha(
   repoDir: string
-): Promise<VenforkConfig | null> {
+): Promise<{ raw: string; sha: string } | null> {
   const fetchResult = await $({
     cwd: repoDir,
     reject: false,
   })`git fetch origin ${CONFIG_BRANCH}`;
   if (fetchResult.exitCode !== 0) {
+    return null;
+  }
+
+  const revParseResult = await $({
+    cwd: repoDir,
+    reject: false,
+  })`git rev-parse FETCH_HEAD`;
+  if (revParseResult.exitCode !== 0) {
+    return null;
+  }
+  const sha = revParseResult.stdout.trim();
+  if (!sha) {
     return null;
   }
 
@@ -457,9 +492,19 @@ export async function readVenforkConfigFromRepo(
   if (showResult.exitCode !== 0) {
     return null;
   }
+  return { raw: showResult.stdout, sha };
+}
 
+/**
+ * Reads venfork configuration from the local repo's orphan `venfork-config` branch.
+ */
+export async function readVenforkConfigFromRepo(
+  repoDir: string
+): Promise<VenforkConfig | null> {
+  const fetched = await fetchConfigContentAndSha(repoDir);
+  if (!fetched) return null;
   try {
-    const config = JSON.parse(showResult.stdout) as VenforkConfig;
+    const config = JSON.parse(fetched.raw) as VenforkConfig;
     return normalizeConfig(config);
   } catch {
     return null;
@@ -467,17 +512,35 @@ export async function readVenforkConfigFromRepo(
 }
 
 /**
- * Updates and force-pushes `venfork-config` with a shallow merge patch.
+ * Like `readVenforkConfigFromRepo` but also returns the SHA of the commit
+ * the config was read from. Used by `updateVenforkConfig` so the
+ * subsequent push can lease against that SHA.
  */
-export async function updateVenforkConfig(
-  repoDir: string,
-  patch: VenforkConfigPatch
-): Promise<VenforkConfig> {
-  const current = await readVenforkConfigFromRepo(repoDir);
-  if (!current) {
-    throw new Error('venfork-config branch not found or invalid');
+async function readVenforkConfigFromRepoWithSha(
+  repoDir: string
+): Promise<{ config: VenforkConfig; sha: string } | null> {
+  const fetched = await fetchConfigContentAndSha(repoDir);
+  if (!fetched) return null;
+  try {
+    const config = JSON.parse(fetched.raw) as VenforkConfig;
+    const normalized = normalizeConfig(config);
+    if (!normalized) return null;
+    return { config: normalized, sha: fetched.sha };
+  } catch {
+    return null;
   }
+}
 
+/**
+ * Apply a `VenforkConfigPatch` on top of an already-read config and return
+ * the fully merged + normalized result. Pulled out so the retry loop in
+ * `updateVenforkConfig` can re-apply the same patch to freshly-read state
+ * after a `--force-with-lease` failure.
+ */
+function applyPatchAndNormalize(
+  current: VenforkConfig,
+  patch: VenforkConfigPatch
+): VenforkConfig {
   const {
     enabledWorkflows: _enabledWorkflowsPatch,
     disabledWorkflows: _disabledWorkflowsPatch,
@@ -552,9 +615,58 @@ export async function updateVenforkConfig(
   if (!normalized) {
     throw new Error('Updated venfork config is invalid');
   }
-
-  await writeConfigBranch(repoDir, normalized, UPDATE_CONFIG_COMMIT_MESSAGE);
   return normalized;
+}
+
+/**
+ * Updates and force-pushes `venfork-config` with a shallow merge patch.
+ *
+ * Auto-retries on `--force-with-lease` failure (i.e. another venfork
+ * command pushed between our read and our write). Each retry re-reads
+ * the now-updated config, re-applies the same patch on top, and pushes
+ * again with the fresh lease SHA — so the losing run's update is
+ * preserved on top of the winning run's, instead of being dropped or
+ * surfaced as a confusing error to the user. Bounded at 3 attempts so
+ * pathological live-locks don't hang the CLI.
+ */
+export async function updateVenforkConfig(
+  repoDir: string,
+  patch: VenforkConfigPatch
+): Promise<VenforkConfig> {
+  const MAX_RETRIES = 3;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+    const read = await readVenforkConfigFromRepoWithSha(repoDir);
+    if (!read) {
+      throw new Error('venfork-config branch not found or invalid');
+    }
+
+    const normalized = applyPatchAndNormalize(read.config, patch);
+
+    try {
+      await writeConfigBranch(
+        repoDir,
+        normalized,
+        UPDATE_CONFIG_COMMIT_MESSAGE,
+        {
+          expectedSha: read.sha,
+        }
+      );
+      return normalized;
+    } catch (err) {
+      if (isLeaseFailure(err) && attempt < MAX_RETRIES - 1) {
+        // Another venfork command updated the config between our read and
+        // our push. Re-read on the next iteration so the merge is on top
+        // of their winning content.
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  throw new Error(
+    `Could not update venfork-config after ${MAX_RETRIES} concurrent-write retries. Re-run the command, or resolve any unexpected state on the venfork-config branch.`
+  );
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,33 @@ import { $ } from 'execa';
 import { parseRepoPath } from './utils.js';
 
 /**
+ * Record kept by `venfork ship` linking an internal review PR (on the private
+ * mirror) to the upstream PR it was promoted to.
+ */
+export interface ShippedBranch {
+  upstreamPrUrl: string;
+  /** SHA pushed to the public fork (== HEAD of the staged branch). */
+  head: string;
+  /** ISO timestamp when ship completed. */
+  shippedAt: string;
+  /** Internal-mirror PR URL, omitted if the branch had no internal PR. */
+  internalPrUrl?: string;
+}
+
+/**
+ * Record kept by `venfork pull-request` so `venfork sync <branch>` can
+ * refresh a pulled-in upstream PR against the latest `pull/<n>/head` ref.
+ */
+export interface PulledPr {
+  upstreamPrNumber: number;
+  upstreamPrUrl: string;
+  /** SHA last fetched onto the local branch. Used for "no-op sync" detection. */
+  head: string;
+  /** ISO timestamp of the last successful fetch. */
+  lastSyncedAt: string;
+}
+
+/**
  * Venfork configuration structure.
  */
 export interface VenforkConfig {
@@ -18,6 +45,10 @@ export interface VenforkConfig {
   };
   enabledWorkflows?: string[];
   disabledWorkflows?: string[];
+  /** Branch -> upstream PR linkage recorded by `venfork ship`. */
+  shippedBranches?: Record<string, ShippedBranch>;
+  /** Branch -> upstream PR tracking recorded by `venfork pull-request`. */
+  pulledPrs?: Record<string, PulledPr>;
 }
 
 const CONFIG_BRANCH = 'venfork-config';
@@ -29,10 +60,20 @@ const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
 export type VenforkConfigPatch = Omit<
   Partial<VenforkConfig>,
-  'enabledWorkflows' | 'disabledWorkflows'
+  | 'enabledWorkflows'
+  | 'disabledWorkflows'
+  | 'shippedBranches'
+  | 'pulledPrs'
 > & {
   enabledWorkflows?: string[] | null;
   disabledWorkflows?: string[] | null;
+  /**
+   * Shallow merge into the existing map. Pass `null` for an entry to delete
+   * just that branch, or `null` for the whole field to clear the map.
+   */
+  shippedBranches?: Record<string, ShippedBranch | null> | null;
+  /** Same shape as `shippedBranches` for pulled-PR tracking. */
+  pulledPrs?: Record<string, PulledPr | null> | null;
 };
 
 /**
@@ -88,6 +129,69 @@ async function writeConfigBranch(
   }
 }
 
+function normalizeShippedBranch(value: unknown): ShippedBranch | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Partial<ShippedBranch>;
+  if (
+    typeof v.upstreamPrUrl !== 'string' ||
+    !v.upstreamPrUrl.trim() ||
+    typeof v.head !== 'string' ||
+    !v.head.trim() ||
+    typeof v.shippedAt !== 'string' ||
+    !v.shippedAt.trim()
+  ) {
+    return null;
+  }
+  const out: ShippedBranch = {
+    upstreamPrUrl: v.upstreamPrUrl,
+    head: v.head,
+    shippedAt: v.shippedAt,
+  };
+  if (typeof v.internalPrUrl === 'string' && v.internalPrUrl.trim()) {
+    out.internalPrUrl = v.internalPrUrl;
+  }
+  return out;
+}
+
+function normalizePulledPr(value: unknown): PulledPr | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Partial<PulledPr>;
+  if (
+    typeof v.upstreamPrNumber !== 'number' ||
+    !Number.isFinite(v.upstreamPrNumber) ||
+    typeof v.upstreamPrUrl !== 'string' ||
+    !v.upstreamPrUrl.trim() ||
+    typeof v.head !== 'string' ||
+    !v.head.trim() ||
+    typeof v.lastSyncedAt !== 'string' ||
+    !v.lastSyncedAt.trim()
+  ) {
+    return null;
+  }
+  return {
+    upstreamPrNumber: v.upstreamPrNumber,
+    upstreamPrUrl: v.upstreamPrUrl,
+    head: v.head,
+    lastSyncedAt: v.lastSyncedAt,
+  };
+}
+
+function normalizeBranchMap<T>(
+  source: Record<string, unknown> | undefined,
+  perEntry: (value: unknown) => T | null
+): Record<string, T> | null {
+  if (!source || typeof source !== 'object') return null;
+  const out: Record<string, T> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (!key.trim()) continue;
+    const normalized = perEntry(value);
+    if (normalized) {
+      out[key] = normalized;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
 function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
   if (!config.version || !config.publicForkUrl || !config.upstreamUrl) {
     return null;
@@ -138,6 +242,26 @@ function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
     } else {
       delete normalized.disabledWorkflows;
     }
+  }
+
+  const shippedBranches = normalizeBranchMap(
+    normalized.shippedBranches,
+    normalizeShippedBranch
+  );
+  if (shippedBranches) {
+    normalized.shippedBranches = shippedBranches;
+  } else {
+    delete normalized.shippedBranches;
+  }
+
+  const pulledPrs = normalizeBranchMap(
+    normalized.pulledPrs,
+    normalizePulledPr
+  );
+  if (pulledPrs) {
+    normalized.pulledPrs = pulledPrs;
+  } else {
+    delete normalized.pulledPrs;
   }
 
   return normalized;
@@ -224,6 +348,8 @@ export async function updateVenforkConfig(
   const {
     enabledWorkflows: _enabledWorkflowsPatch,
     disabledWorkflows: _disabledWorkflowsPatch,
+    shippedBranches: _shippedBranchesPatch,
+    pulledPrs: _pulledPrsPatch,
     ...basePatch
   } = patch;
 
@@ -250,6 +376,21 @@ export async function updateVenforkConfig(
     merged.disabledWorkflows = patch.disabledWorkflows;
   }
 
+  if (patch.shippedBranches === null) {
+    delete merged.shippedBranches;
+  } else if (patch.shippedBranches !== undefined) {
+    merged.shippedBranches = mergeBranchMap(
+      merged.shippedBranches,
+      patch.shippedBranches
+    );
+  }
+
+  if (patch.pulledPrs === null) {
+    delete merged.pulledPrs;
+  } else if (patch.pulledPrs !== undefined) {
+    merged.pulledPrs = mergeBranchMap(merged.pulledPrs, patch.pulledPrs);
+  }
+
   if (merged.schedule && !merged.schedule.cron?.trim()) {
     throw new Error('schedule.cron is required when schedule is configured');
   }
@@ -261,4 +402,24 @@ export async function updateVenforkConfig(
 
   await writeConfigBranch(repoDir, normalized, UPDATE_CONFIG_COMMIT_MESSAGE);
   return normalized;
+}
+
+/**
+ * Apply a partial patch to a branch-keyed map. Per-entry `null` deletes the
+ * entry; absent entries are preserved. Returns undefined when the result is
+ * empty so the field gets removed from the config object.
+ */
+function mergeBranchMap<T>(
+  current: Record<string, T> | undefined,
+  patch: Record<string, T | null>
+): Record<string, T> | undefined {
+  const merged: Record<string, T> = { ...(current ?? {}) };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null) {
+      delete merged[key];
+    } else {
+      merged[key] = value;
+    }
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,6 +33,32 @@ export interface PulledPr {
 }
 
 /**
+ * Record kept by `venfork issue stage` linking an internal issue (private
+ * mirror) to the upstream issue it was promoted to.
+ */
+export interface ShippedIssue {
+  internalIssueNumber: number;
+  internalIssueUrl: string;
+  upstreamIssueNumber: number;
+  upstreamIssueUrl: string;
+  /** ISO timestamp when ship completed. */
+  shippedAt: string;
+}
+
+/**
+ * Record kept by `venfork issue pull` linking an upstream issue to the
+ * internal issue created on the mirror for team triage.
+ */
+export interface PulledIssue {
+  upstreamIssueNumber: number;
+  upstreamIssueUrl: string;
+  internalIssueNumber: number;
+  internalIssueUrl: string;
+  /** ISO timestamp when the internal issue was created. */
+  pulledAt: string;
+}
+
+/**
  * Venfork configuration structure.
  */
 export interface VenforkConfig {
@@ -45,10 +71,20 @@ export interface VenforkConfig {
   };
   enabledWorkflows?: string[];
   disabledWorkflows?: string[];
-  /** Branch -> upstream PR linkage recorded by `venfork ship`. */
+  /** Branch -> upstream PR linkage recorded by `venfork stage --pr`. */
   shippedBranches?: Record<string, ShippedBranch>;
   /** Branch -> upstream PR tracking recorded by `venfork pull-request`. */
   pulledPrs?: Record<string, PulledPr>;
+  /**
+   * Internal-issue-number-as-string -> upstream issue linkage recorded by
+   * `venfork issue stage`.
+   */
+  shippedIssues?: Record<string, ShippedIssue>;
+  /**
+   * Internal-issue-number-as-string -> upstream issue linkage recorded by
+   * `venfork issue pull`.
+   */
+  pulledIssues?: Record<string, PulledIssue>;
 }
 
 const CONFIG_BRANCH = 'venfork-config';
@@ -60,7 +96,12 @@ const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
 
 export type VenforkConfigPatch = Omit<
   Partial<VenforkConfig>,
-  'enabledWorkflows' | 'disabledWorkflows' | 'shippedBranches' | 'pulledPrs'
+  | 'enabledWorkflows'
+  | 'disabledWorkflows'
+  | 'shippedBranches'
+  | 'pulledPrs'
+  | 'shippedIssues'
+  | 'pulledIssues'
 > & {
   enabledWorkflows?: string[] | null;
   disabledWorkflows?: string[] | null;
@@ -71,6 +112,8 @@ export type VenforkConfigPatch = Omit<
   shippedBranches?: Record<string, ShippedBranch | null> | null;
   /** Same shape as `shippedBranches` for pulled-PR tracking. */
   pulledPrs?: Record<string, PulledPr | null> | null;
+  shippedIssues?: Record<string, ShippedIssue | null> | null;
+  pulledIssues?: Record<string, PulledIssue | null> | null;
 };
 
 /**
@@ -173,6 +216,58 @@ function normalizePulledPr(value: unknown): PulledPr | null {
   };
 }
 
+function normalizeShippedIssue(value: unknown): ShippedIssue | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Partial<ShippedIssue>;
+  if (
+    typeof v.internalIssueNumber !== 'number' ||
+    !Number.isFinite(v.internalIssueNumber) ||
+    typeof v.internalIssueUrl !== 'string' ||
+    !v.internalIssueUrl.trim() ||
+    typeof v.upstreamIssueNumber !== 'number' ||
+    !Number.isFinite(v.upstreamIssueNumber) ||
+    typeof v.upstreamIssueUrl !== 'string' ||
+    !v.upstreamIssueUrl.trim() ||
+    typeof v.shippedAt !== 'string' ||
+    !v.shippedAt.trim()
+  ) {
+    return null;
+  }
+  return {
+    internalIssueNumber: v.internalIssueNumber,
+    internalIssueUrl: v.internalIssueUrl,
+    upstreamIssueNumber: v.upstreamIssueNumber,
+    upstreamIssueUrl: v.upstreamIssueUrl,
+    shippedAt: v.shippedAt,
+  };
+}
+
+function normalizePulledIssue(value: unknown): PulledIssue | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Partial<PulledIssue>;
+  if (
+    typeof v.upstreamIssueNumber !== 'number' ||
+    !Number.isFinite(v.upstreamIssueNumber) ||
+    typeof v.upstreamIssueUrl !== 'string' ||
+    !v.upstreamIssueUrl.trim() ||
+    typeof v.internalIssueNumber !== 'number' ||
+    !Number.isFinite(v.internalIssueNumber) ||
+    typeof v.internalIssueUrl !== 'string' ||
+    !v.internalIssueUrl.trim() ||
+    typeof v.pulledAt !== 'string' ||
+    !v.pulledAt.trim()
+  ) {
+    return null;
+  }
+  return {
+    upstreamIssueNumber: v.upstreamIssueNumber,
+    upstreamIssueUrl: v.upstreamIssueUrl,
+    internalIssueNumber: v.internalIssueNumber,
+    internalIssueUrl: v.internalIssueUrl,
+    pulledAt: v.pulledAt,
+  };
+}
+
 function normalizeBranchMap<T>(
   source: Record<string, unknown> | undefined,
   perEntry: (value: unknown) => T | null
@@ -256,6 +351,26 @@ function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
     normalized.pulledPrs = pulledPrs;
   } else {
     delete normalized.pulledPrs;
+  }
+
+  const shippedIssues = normalizeBranchMap(
+    normalized.shippedIssues,
+    normalizeShippedIssue
+  );
+  if (shippedIssues) {
+    normalized.shippedIssues = shippedIssues;
+  } else {
+    delete normalized.shippedIssues;
+  }
+
+  const pulledIssues = normalizeBranchMap(
+    normalized.pulledIssues,
+    normalizePulledIssue
+  );
+  if (pulledIssues) {
+    normalized.pulledIssues = pulledIssues;
+  } else {
+    delete normalized.pulledIssues;
   }
 
   return normalized;
@@ -344,6 +459,8 @@ export async function updateVenforkConfig(
     disabledWorkflows: _disabledWorkflowsPatch,
     shippedBranches: _shippedBranchesPatch,
     pulledPrs: _pulledPrsPatch,
+    shippedIssues: _shippedIssuesPatch,
+    pulledIssues: _pulledIssuesPatch,
     ...basePatch
   } = patch;
 
@@ -383,6 +500,24 @@ export async function updateVenforkConfig(
     delete merged.pulledPrs;
   } else if (patch.pulledPrs !== undefined) {
     merged.pulledPrs = mergeBranchMap(merged.pulledPrs, patch.pulledPrs);
+  }
+
+  if (patch.shippedIssues === null) {
+    delete merged.shippedIssues;
+  } else if (patch.shippedIssues !== undefined) {
+    merged.shippedIssues = mergeBranchMap(
+      merged.shippedIssues,
+      patch.shippedIssues
+    );
+  }
+
+  if (patch.pulledIssues === null) {
+    delete merged.pulledIssues;
+  } else if (patch.pulledIssues !== undefined) {
+    merged.pulledIssues = mergeBranchMap(
+      merged.pulledIssues,
+      patch.pulledIssues
+    );
   }
 
   if (merged.schedule && !merged.schedule.cron?.trim()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,8 @@ async function main(): Promise<void> {
         draft: parsed.draft,
         title: parsed.title,
         base: parsed.base,
+        internalPrNumber: parsed.internalPrNumber,
+        noUpdateExisting: parsed.noUpdateExisting,
       });
       break;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as p from '@clack/prompts';
 import {
   cloneCommand,
+  pullRequestCommand,
   scheduleCommand,
   setupCommand,
   showHelp,
@@ -11,7 +12,9 @@ import {
   syncCommand,
   workflowsCommand,
 } from './commands.js';
+import { parsePullRequestCliArgs } from './pull-request-args.js';
 import { parseSetupCliArgs } from './setup-args.js';
+import { parseStageCliArgs } from './stage-args.js';
 import { parseWorkflowsCliArgs } from './workflows-args.js';
 
 /**
@@ -51,15 +54,30 @@ async function main(): Promise<void> {
     case 'schedule':
       await scheduleCommand(args[1], args[2]);
       break;
-    case 'stage':
-      await stageCommand(args[1]);
+    case 'stage': {
+      const parsed = parseStageCliArgs(args.slice(1));
+      await stageCommand(parsed.branch, {
+        createPr: parsed.createPr,
+        draft: parsed.draft,
+        title: parsed.title,
+        base: parsed.base,
+      });
       break;
+    }
     case 'status':
       await statusCommand();
       break;
     case 'workflows': {
       const parsed = parseWorkflowsCliArgs(args.slice(1));
       await workflowsCommand(parsed.action, parsed.workflows);
+      break;
+    }
+    case 'pull-request': {
+      const parsed = parsePullRequestCliArgs(args.slice(1));
+      await pullRequestCommand(parsed.pr, {
+        branchName: parsed.branchName,
+        push: parsed.push,
+      });
       break;
     }
     default:

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import * as p from '@clack/prompts';
 import {
   cloneCommand,
+  issueCommand,
   pullRequestCommand,
   scheduleCommand,
   setupCommand,
@@ -12,6 +13,7 @@ import {
   syncCommand,
   workflowsCommand,
 } from './commands.js';
+import { parseIssueCliArgs } from './issue-args.js';
 import { parsePullRequestCliArgs } from './pull-request-args.js';
 import { parseSetupCliArgs } from './setup-args.js';
 import { parseStageCliArgs } from './stage-args.js';
@@ -77,6 +79,13 @@ async function main(): Promise<void> {
       await pullRequestCommand(parsed.pr, {
         branchName: parsed.branchName,
         push: parsed.push,
+      });
+      break;
+    }
+    case 'issue': {
+      const parsed = parseIssueCliArgs(args.slice(1));
+      await issueCommand(parsed.action, parsed.target, {
+        title: parsed.title,
       });
       break;
     }

--- a/src/issue-args.ts
+++ b/src/issue-args.ts
@@ -1,0 +1,65 @@
+export type IssueAction = 'stage' | 'pull';
+
+export type ParsedIssueArgs = {
+  action?: IssueAction;
+  /** Issue number or URL, depending on action. */
+  target?: string;
+  /** Override issue title (optional). */
+  title?: string;
+};
+
+function consumeValue(
+  flag: string,
+  args: string[],
+  i: number
+): { value: string; consumed: number } {
+  const equalsForm = `${flag}=`;
+  const a = args[i];
+  if (a === flag) {
+    const v = args[i + 1];
+    if (!v || v.startsWith('--')) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 1 };
+  }
+  if (a.startsWith(equalsForm)) {
+    const v = a.slice(equalsForm.length);
+    if (!v) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 0 };
+  }
+  throw new Error(`internal: consumeValue called for non-matching arg ${a}`);
+}
+
+/**
+ * Parse `venfork issue ...` argv after the `issue` token.
+ * Layout: `venfork issue <stage|pull> <number-or-url> [--title <text>]`
+ */
+export function parseIssueCliArgs(issueArgs: string[]): ParsedIssueArgs {
+  const positional: string[] = [];
+  let title: string | undefined;
+
+  for (let i = 0; i < issueArgs.length; i++) {
+    const a = issueArgs[i];
+    if (a === '--title' || a.startsWith('--title=')) {
+      const { value, consumed } = consumeValue('--title', issueArgs, i);
+      title = value;
+      i += consumed;
+      continue;
+    }
+    positional.push(a);
+  }
+
+  const rawAction = positional[0];
+  let action: IssueAction | undefined;
+  if (rawAction === 'stage' || rawAction === 'pull') {
+    action = rawAction;
+  } else if (rawAction !== undefined) {
+    throw new Error(
+      `Unknown issue action: ${rawAction}. Expected one of: stage, pull.`
+    );
+  }
+
+  return {
+    action,
+    target: positional[1],
+    title,
+  };
+}

--- a/src/pull-request-args.ts
+++ b/src/pull-request-args.ts
@@ -1,0 +1,57 @@
+export type ParsedPullRequestArgs = {
+  pr?: string;
+  branchName?: string;
+  push: boolean;
+};
+
+function consumeValue(
+  flag: string,
+  args: string[],
+  i: number
+): { value: string; consumed: number } {
+  const equalsForm = `${flag}=`;
+  const a = args[i];
+  if (a === flag) {
+    const v = args[i + 1];
+    if (!v || v.startsWith('--')) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 1 };
+  }
+  if (a.startsWith(equalsForm)) {
+    const v = a.slice(equalsForm.length);
+    if (!v) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 0 };
+  }
+  throw new Error(`internal: consumeValue called for non-matching arg ${a}`);
+}
+
+/**
+ * Parse `venfork pull-request ...` argv after the command token.
+ */
+export function parsePullRequestCliArgs(
+  prArgs: string[]
+): ParsedPullRequestArgs {
+  const positional: string[] = [];
+  let branchName: string | undefined;
+  let push = true;
+
+  for (let i = 0; i < prArgs.length; i++) {
+    const a = prArgs[i];
+    if (a === '--no-push') {
+      push = false;
+      continue;
+    }
+    if (a === '--branch-name' || a.startsWith('--branch-name=')) {
+      const { value, consumed } = consumeValue('--branch-name', prArgs, i);
+      branchName = value;
+      i += consumed;
+      continue;
+    }
+    positional.push(a);
+  }
+
+  return {
+    pr: positional[0],
+    branchName,
+    push,
+  };
+}

--- a/src/stage-args.ts
+++ b/src/stage-args.ts
@@ -1,0 +1,76 @@
+export type ParsedStageArgs = {
+  branch?: string;
+  /** When true, also open an upstream PR after staging. */
+  createPr: boolean;
+  /** When true, the upstream PR is opened as a draft. Implies --pr. */
+  draft: boolean;
+  /** Override the upstream PR title; default is the internal PR title. */
+  title?: string;
+  /** Override the upstream base branch; default is upstream's default branch. */
+  base?: string;
+};
+
+function consumeValue(
+  flag: string,
+  args: string[],
+  i: number
+): { value: string; consumed: number } {
+  const equalsForm = `${flag}=`;
+  const a = args[i];
+  if (a === flag) {
+    const v = args[i + 1];
+    if (!v || v.startsWith('--')) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 1 };
+  }
+  if (a.startsWith(equalsForm)) {
+    const v = a.slice(equalsForm.length);
+    if (!v) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 0 };
+  }
+  throw new Error(`internal: consumeValue called for non-matching arg ${a}`);
+}
+
+/**
+ * Parse `venfork stage ...` argv after the `stage` token.
+ */
+export function parseStageCliArgs(stageArgs: string[]): ParsedStageArgs {
+  const positional: string[] = [];
+  let createPr = false;
+  let draft = false;
+  let title: string | undefined;
+  let base: string | undefined;
+
+  for (let i = 0; i < stageArgs.length; i++) {
+    const a = stageArgs[i];
+    if (a === '--pr') {
+      createPr = true;
+      continue;
+    }
+    if (a === '--draft') {
+      draft = true;
+      createPr = true;
+      continue;
+    }
+    if (a === '--title' || a.startsWith('--title=')) {
+      const { value, consumed } = consumeValue('--title', stageArgs, i);
+      title = value;
+      i += consumed;
+      continue;
+    }
+    if (a === '--base' || a.startsWith('--base=')) {
+      const { value, consumed } = consumeValue('--base', stageArgs, i);
+      base = value;
+      i += consumed;
+      continue;
+    }
+    positional.push(a);
+  }
+
+  return {
+    branch: positional[0],
+    createPr,
+    draft,
+    title,
+    base,
+  };
+}

--- a/src/stage-args.ts
+++ b/src/stage-args.ts
@@ -8,6 +8,18 @@ export type ParsedStageArgs = {
   title?: string;
   /** Override the upstream base branch; default is upstream's default branch. */
   base?: string;
+  /**
+   * Pin the internal review PR by number, instead of letting venfork pick
+   * the most recent one for the branch. Use when a branch has had multiple
+   * internal PRs and you want to ship from a specific one.
+   */
+  internalPrNumber?: number;
+  /**
+   * When true, don't update an existing upstream PR body on re-runs.
+   * Default behaviour re-syncs the body via `gh pr edit` so addressing
+   * internal review feedback re-publishes upstream.
+   */
+  noUpdateExisting: boolean;
 };
 
 function consumeValue(
@@ -39,6 +51,8 @@ export function parseStageCliArgs(stageArgs: string[]): ParsedStageArgs {
   let draft = false;
   let title: string | undefined;
   let base: string | undefined;
+  let internalPrNumber: number | undefined;
+  let noUpdateExisting = false;
 
   for (let i = 0; i < stageArgs.length; i++) {
     const a = stageArgs[i];
@@ -49,6 +63,10 @@ export function parseStageCliArgs(stageArgs: string[]): ParsedStageArgs {
     if (a === '--draft') {
       draft = true;
       createPr = true;
+      continue;
+    }
+    if (a === '--no-update-existing') {
+      noUpdateExisting = true;
       continue;
     }
     if (a === '--title' || a.startsWith('--title=')) {
@@ -63,6 +81,16 @@ export function parseStageCliArgs(stageArgs: string[]): ParsedStageArgs {
       i += consumed;
       continue;
     }
+    if (a === '--internal-pr' || a.startsWith('--internal-pr=')) {
+      const { value, consumed } = consumeValue('--internal-pr', stageArgs, i);
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error('--internal-pr requires a positive integer');
+      }
+      internalPrNumber = parsed;
+      i += consumed;
+      continue;
+    }
     positional.push(a);
   }
 
@@ -72,5 +100,7 @@ export function parseStageCliArgs(stageArgs: string[]): ParsedStageArgs {
     draft,
     title,
     base,
+    internalPrNumber,
+    noUpdateExisting,
   };
 }

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -2640,6 +2640,54 @@ describe('syncCommand - pulled PR branches', () => {
       execaCalls.some((cmd) => cmd.includes('git fetch upstream pull/'))
     ).toBe(false);
   });
+
+  test('does NOT update pulledPrs when push to origin fails', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+        pulledPrs: {
+          'upstream-pr/42': {
+            upstreamPrNumber: 42,
+            upstreamPrUrl: 'https://github.com/up/repo/pull/42',
+            head: 'oldsha',
+            lastSyncedAt: '2026-04-28T09:00:00Z',
+          },
+        },
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git fetch upstream pull/42/head:upstream-pr/42', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse upstream-pr/42', {
+      exitCode: 0,
+      stdout: 'newsha\n',
+      stderr: '',
+    });
+    // Mirror push fails — config write must NOT happen, otherwise pulledPrs
+    // would record a head/lastSyncedAt that doesn't match the mirror.
+    mockResponses.set('git push origin upstream-pr/42 --force-with-lease', {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: remote rejected',
+    });
+
+    try {
+      await syncCommand('upstream-pr/42');
+    } catch {
+      // ignore
+    }
+
+    // No new write to venfork-config branch.
+    expect(
+      execaCalls.some((cmd) => cmd.includes('venfork-config:venfork-config'))
+    ).toBe(false);
+  });
 });
 
 describe('issueCommand', () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1222,6 +1222,304 @@ describe('stageCommand', () => {
 
     expect(execaCalls.some((cmd) => cmd.includes('gh pr create'))).toBe(false);
   });
+
+  test('--pr internal-PR lookup passes --state with value as separate args', async () => {
+    // Regression for the bug where `--state open` was a single execa template
+    // interpolation and gh silently filtered wrong, producing zero results.
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      { exitCode: 0, stdout: '[]', stderr: '' }
+    );
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/pull/200\n',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch', { createPr: true });
+    } catch {
+      // ignore
+    }
+
+    // The rendered command must contain "--state open" (space-separated).
+    expect(
+      execaCalls.some(
+        (cmd) => cmd.includes('gh pr list') && / --state open(?: |$)/.test(cmd)
+      )
+    ).toBe(true);
+  });
+
+  test('--internal-pr <n> uses gh pr view by id and skips the list lookup', async () => {
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('gh pr view 99 --repo owner/repo-private', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 99,
+        url: 'https://github.com/owner/repo-private/pull/99',
+        title: 'pinned title',
+        body: 'pinned body',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/pull/300\n',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch', {
+        createPr: true,
+        internalPrNumber: 99,
+      });
+    } catch {
+      // ignore
+    }
+
+    // gh pr view by id was called
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh pr view 99') && cmd.includes('owner/repo-private')
+      )
+    ).toBe(true);
+    // and gh pr list was NOT called (the override skips list)
+    expect(execaCalls.some((cmd) => cmd.includes('gh pr list'))).toBe(false);
+  });
+
+  test('--pr auto-updates body via gh pr edit when upstream PR already exists', async () => {
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      { exitCode: 0, stdout: '[]', stderr: '' }
+    );
+    // gh pr create exits non-zero with an "already exists" error containing
+    // the existing PR URL — createUpstreamPr surfaces alreadyExists: true.
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 1,
+      stdout: '',
+      stderr:
+        'a pull request for branch "feature-branch" into branch "main" already exists: https://github.com/up/repo/pull/77',
+    });
+    mockResponses.set('gh pr edit https://github.com/up/repo/pull/77', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch', { createPr: true });
+    } catch {
+      // ignore
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh pr edit https://github.com/up/repo/pull/77') &&
+          cmd.includes('--body-file -')
+      )
+    ).toBe(true);
+  });
+
+  test('--pr respects --no-update-existing on already-exists path', async () => {
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      { exitCode: 0, stdout: '[]', stderr: '' }
+    );
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 1,
+      stdout: '',
+      stderr:
+        'a pull request for branch "feature-branch" into branch "main" already exists: https://github.com/up/repo/pull/77',
+    });
+
+    try {
+      await stageCommand('feature-branch', {
+        createPr: true,
+        noUpdateExisting: true,
+      });
+    } catch {
+      // ignore
+    }
+
+    expect(execaCalls.some((cmd) => cmd.includes('gh pr edit'))).toBe(false);
+  });
+
+  test('--pr with VENFORK_NONINTERACTIVE=1 skips the confirm prompt', async () => {
+    process.env.VENFORK_NONINTERACTIVE = '1';
+    // Default confirmResponse=true would also let the test pass even if the
+    // prompt fired; flip it to false so a successful flow PROVES the prompt
+    // was bypassed.
+    confirmResponse = false;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      { exitCode: 0, stdout: '[]', stderr: '' }
+    );
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/pull/400\n',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch', { createPr: true });
+    } finally {
+      delete process.env.VENFORK_NONINTERACTIVE;
+    }
+
+    // The prompt was bypassed, so we reached the push + gh pr create path
+    // even though confirmResponse=false would have cancelled it.
+    expect(execaCalls.some((cmd) => cmd.includes('gh pr create'))).toBe(true);
+  });
 });
 
 describe('scheduleCommand', () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -2405,7 +2405,10 @@ describe('pullRequestCommand', () => {
     ).toBe(true);
   });
 
-  test('--no-push skips push to origin', async () => {
+  test('--no-push skips push to origin AND skips pulledPrs linkage', async () => {
+    // The linkage skip is important: with --no-push the mirror doesn't have
+    // the branch, so a later `venfork sync <branch>` shouldn't push it
+    // (which it would do if a pulledPrs entry were recorded).
     setupPrCommonMocks();
     try {
       await pullRequestCommand('42', { push: false });
@@ -2415,6 +2418,10 @@ describe('pullRequestCommand', () => {
     expect(execaCalls.some((cmd) => cmd.includes('git push origin'))).toBe(
       false
     );
+    // updateVenforkConfig pushes the venfork-config branch — must not happen.
+    expect(
+      execaCalls.some((cmd) => cmd.includes('venfork-config:venfork-config'))
+    ).toBe(false);
   });
 
   test('--branch-name overrides the local branch', async () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -187,6 +187,7 @@ mock.module('@clack/prompts', () => ({
 // Import commands (will use mocked execa, fs, and prompts)
 import {
   cloneCommand,
+  pullRequestCommand,
   scheduleCommand,
   setupCommand,
   showHelp,
@@ -975,6 +976,250 @@ describe('stageCommand', () => {
     );
     expect(pickCalls.some((cmd) => cmd.includes('feat111'))).toBe(true);
     expect(pickCalls.some((cmd) => cmd.includes('feat222'))).toBe(true);
+  });
+
+  test('--pr looks up internal PR, redacts internal blocks, opens upstream PR, records shippedBranches', async () => {
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    // Schedule disabled — keep the simpler push path.
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      {
+        exitCode: 0,
+        stdout: JSON.stringify([
+          {
+            number: 7,
+            url: 'https://github.com/owner/repo-private/pull/7',
+            title: 'feat: add auth',
+            body: 'Public summary.\n\n<!-- venfork:internal -->client X requires Y<!-- /venfork:internal -->\n\nMore public detail.',
+          },
+        ]),
+        stderr: '',
+      }
+    );
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/pull/123\n',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch', { createPr: true });
+    } catch {
+      // updateVenforkConfig may fail on writeFile mock — fine for this test.
+    }
+
+    // Internal PR lookup happened via gh.
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh pr list') &&
+          cmd.includes('owner/repo-private') &&
+          cmd.includes('feature-branch')
+      )
+    ).toBe(true);
+
+    // Upstream PR creation hit the right repo + cross-fork head.
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh pr create --repo up/repo') &&
+          cmd.includes('--head owner:feature-branch')
+      )
+    ).toBe(true);
+
+    // The body sent to gh has the internal block stripped.
+    // (We can't easily inspect the piped --body-file - input here, but the
+    // payload was rendered via translateInternalBody and shown to the user.)
+    expect(execaCalls.some((cmd) => cmd.includes('--body-file -'))).toBe(true);
+  });
+
+  test('--pr surfaces "already exists" without throwing', async () => {
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      { exitCode: 0, stdout: '[]', stderr: '' }
+    );
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 1,
+      stdout: '',
+      stderr:
+        'a pull request for branch "feature-branch" into branch "main" already exists: https://github.com/up/repo/pull/99',
+    });
+
+    let threw = false;
+    try {
+      await stageCommand('feature-branch', { createPr: true });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+  });
+
+  test('--draft passes --draft to gh pr create', async () => {
+    confirmResponse = true;
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-private.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set(
+      'gh pr list --repo owner/repo-private --head feature-branch',
+      { exitCode: 0, stdout: '[]', stderr: '' }
+    );
+    mockResponses.set('gh pr create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/pull/200\n',
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch', {
+        createPr: true,
+        draft: true,
+      });
+    } catch {
+      // ignore
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) => cmd.includes('gh pr create') && cmd.includes('--draft')
+      )
+    ).toBe(true);
+  });
+
+  test('default behaviour (no --pr) still prints the compare URL and skips gh pr create', async () => {
+    confirmResponse = true;
+    mockResponses.set('git rev-parse --verify feature-branch', {
+      exitCode: 0,
+      stdout: 'cafef00d',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url public', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/repo-fork.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/repo-fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await stageCommand('feature-branch');
+    } catch {
+      // ignore
+    }
+
+    expect(execaCalls.some((cmd) => cmd.includes('gh pr create'))).toBe(false);
   });
 });
 
@@ -1766,5 +2011,327 @@ describe('statusCommand - error paths', () => {
     expect(execaCalls.some((cmd) => cmd.includes('git remote get-url'))).toBe(
       true
     );
+  });
+});
+
+describe('pullRequestCommand', () => {
+  function setupPrCommonMocks() {
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('gh pr view 42 --repo up/repo', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 42,
+        title: 'Add cool feature',
+        body: 'Body of upstream PR.',
+        url: 'https://github.com/up/repo/pull/42',
+        state: 'OPEN',
+        baseRefName: 'main',
+        headRefName: 'feat/cool',
+        author: { login: 'contributor' },
+        headRepositoryOwner: { login: 'forker' },
+      }),
+      stderr: '',
+    });
+    // Local branch does NOT already exist (rev-parse --verify fails)
+    mockResponses.set('git rev-parse --verify upstream-pr/42', {
+      exitCode: 1,
+      stdout: '',
+      stderr: 'fatal: bad revision',
+    });
+    mockResponses.set('git fetch upstream pull/42/head:upstream-pr/42', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse upstream-pr/42', {
+      exitCode: 0,
+      stdout: 'aaaaaaaaaaaaaaaa\n',
+      stderr: '',
+    });
+    mockResponses.set('git push origin upstream-pr/42', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+  }
+
+  test('happy path: integer arg → fetch pull/N/head + push to origin + record entry', async () => {
+    setupPrCommonMocks();
+
+    try {
+      await pullRequestCommand('42');
+    } catch {
+      // ignore — config writeback may fail in mocked env
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) => cmd.includes('gh pr view 42') && cmd.includes('--repo up/repo')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git fetch upstream pull/42/head:upstream-pr/42')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git push origin upstream-pr/42'))
+    ).toBe(true);
+  });
+
+  test('URL arg resolves to the same PR number', async () => {
+    setupPrCommonMocks();
+    try {
+      await pullRequestCommand('https://github.com/up/repo/pull/42');
+    } catch {
+      // ignore
+    }
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git fetch upstream pull/42/head:upstream-pr/42')
+      )
+    ).toBe(true);
+  });
+
+  test('--no-push skips push to origin', async () => {
+    setupPrCommonMocks();
+    try {
+      await pullRequestCommand('42', { push: false });
+    } catch {
+      // ignore
+    }
+    expect(execaCalls.some((cmd) => cmd.includes('git push origin'))).toBe(
+      false
+    );
+  });
+
+  test('--branch-name overrides the local branch', async () => {
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('gh pr view 42 --repo up/repo', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 42,
+        title: 't',
+        body: '',
+        url: 'https://github.com/up/repo/pull/42',
+        state: 'OPEN',
+        baseRefName: 'main',
+        headRefName: 'feat/x',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git fetch upstream pull/42/head:review/up-42', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse review/up-42', {
+      exitCode: 0,
+      stdout: 'bbbbbbbbbbbbbbbb\n',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await pullRequestCommand('42', { branchName: 'review/up-42' });
+    } catch {
+      // ignore
+    }
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git fetch upstream pull/42/head:review/up-42')
+      )
+    ).toBe(true);
+  });
+
+  test('refuses to clobber an existing local branch (no --branch-name)', async () => {
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('gh pr view 42 --repo up/repo', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 42,
+        title: 't',
+        body: '',
+        url: 'https://github.com/up/repo/pull/42',
+        state: 'OPEN',
+        baseRefName: 'main',
+        headRefName: 'feat/x',
+      }),
+      stderr: '',
+    });
+    // Local branch already exists.
+    mockResponses.set('git rev-parse --verify upstream-pr/42', {
+      exitCode: 0,
+      stdout: 'existinghead',
+      stderr: '',
+    });
+
+    await expect(pullRequestCommand('42')).rejects.toThrow(
+      'process.exit called'
+    );
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git fetch upstream pull/42'))
+    ).toBe(false);
+  });
+
+  test('rejects malformed PR ref', async () => {
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    await expect(pullRequestCommand('not-a-pr-ref')).rejects.toThrow(
+      'process.exit called'
+    );
+  });
+});
+
+describe('syncCommand - pulled PR branches', () => {
+  test('refreshes upstream-pr/<n> via pull/<n>/head and updates origin', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+        pulledPrs: {
+          'upstream-pr/42': {
+            upstreamPrNumber: 42,
+            upstreamPrUrl: 'https://github.com/up/repo/pull/42',
+            head: 'oldsha',
+            lastSyncedAt: '2026-04-28T09:00:00Z',
+          },
+        },
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git fetch upstream pull/42/head:upstream-pr/42', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse upstream-pr/42', {
+      exitCode: 0,
+      stdout: 'newsha\n',
+      stderr: '',
+    });
+    mockResponses.set('git push origin upstream-pr/42 --force-with-lease', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('upstream-pr/42');
+    } catch {
+      // updateVenforkConfig may fail under mocks — fine
+    }
+
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git fetch upstream pull/42/head:upstream-pr/42')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git push origin upstream-pr/42 --force-with-lease')
+      )
+    ).toBe(true);
+    // Should NOT run the default-branch divergence flow.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git push origin upstream/main:refs/heads/main')
+      )
+    ).toBe(false);
+  });
+
+  test('falls back to convention when no pulledPrs entry exists', async () => {
+    mockResponses.set('git fetch upstream pull/99/head:upstream-pr/99', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse upstream-pr/99', {
+      exitCode: 0,
+      stdout: 'sha99\n',
+      stderr: '',
+    });
+    mockResponses.set('git push origin upstream-pr/99 --force-with-lease', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    // No config entry — relies on the upstream-pr/N convention match.
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('upstream-pr/99');
+    } catch {
+      // ignore
+    }
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git fetch upstream pull/99/head:upstream-pr/99')
+      )
+    ).toBe(true);
+  });
+
+  test('non-pulled branch falls through to default-branch sync flow', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // ignore
+    }
+    // Must not have hit the pull/N/head fetch path.
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git fetch upstream pull/'))
+    ).toBe(false);
   });
 });

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -187,6 +187,7 @@ mock.module('@clack/prompts', () => ({
 // Import commands (will use mocked execa, fs, and prompts)
 import {
   cloneCommand,
+  issueCommand,
   pullRequestCommand,
   scheduleCommand,
   setupCommand,
@@ -2333,5 +2334,160 @@ describe('syncCommand - pulled PR branches', () => {
     expect(
       execaCalls.some((cmd) => cmd.includes('git fetch upstream pull/'))
     ).toBe(false);
+  });
+});
+
+describe('issueCommand', () => {
+  function setupCommonRemotes() {
+    mockResponses.set('git remote get-url origin', {
+      exitCode: 0,
+      stdout: 'git@github.com:owner/mirror.git',
+      stderr: '',
+    });
+    mockResponses.set('git remote get-url upstream', {
+      exitCode: 0,
+      stdout: 'git@github.com:up/repo.git',
+      stderr: '',
+    });
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:owner/fork.git',
+        upstreamUrl: 'git@github.com:up/repo.git',
+      }),
+      stderr: '',
+    });
+  }
+
+  test('stage: reads internal issue, redacts, posts upstream, records linkage', async () => {
+    setupCommonRemotes();
+    confirmResponse = true;
+    mockResponses.set('gh issue view 7 --repo owner/mirror', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 7,
+        url: 'https://github.com/owner/mirror/issues/7',
+        title: 'Bug: things break',
+        body: 'Public summary.\n<!-- venfork:internal -->Client X is blocked.<!-- /venfork:internal -->\nMore detail.',
+        state: 'OPEN',
+        author: { login: 'me' },
+      }),
+      stderr: '',
+    });
+    mockResponses.set('gh issue create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/issues/99\n',
+      stderr: '',
+    });
+
+    try {
+      await issueCommand('stage', '7');
+    } catch {
+      // venfork-config write may fail under mocks
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh issue view 7') && cmd.includes('--repo owner/mirror')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh issue create --repo up/repo') &&
+          cmd.includes('--body-file -')
+      )
+    ).toBe(true);
+  });
+
+  test('pull: reads upstream issue, posts internal, records linkage', async () => {
+    setupCommonRemotes();
+    confirmResponse = true;
+    mockResponses.set('gh issue view 1234 --repo up/repo', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 1234,
+        url: 'https://github.com/up/repo/issues/1234',
+        title: 'Feature request: foo',
+        body: 'Body text.',
+        state: 'OPEN',
+        author: { login: 'reporter' },
+      }),
+      stderr: '',
+    });
+    mockResponses.set('gh issue create --repo owner/mirror', {
+      exitCode: 0,
+      stdout: 'https://github.com/owner/mirror/issues/12\n',
+      stderr: '',
+    });
+
+    try {
+      await issueCommand('pull', '1234');
+    } catch {
+      // ignore config-write fallout
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh issue view 1234') && cmd.includes('--repo up/repo')
+      )
+    ).toBe(true);
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('gh issue create --repo owner/mirror')
+      )
+    ).toBe(true);
+  });
+
+  test('rejects unknown action', async () => {
+    setupCommonRemotes();
+    await expect(
+      // biome-ignore lint/suspicious/noExplicitAny: testing invalid runtime input
+      issueCommand('burn' as any, '7')
+    ).rejects.toThrow('process.exit called');
+  });
+
+  test('rejects missing target', async () => {
+    setupCommonRemotes();
+    await expect(issueCommand('stage', undefined)).rejects.toThrow(
+      'process.exit called'
+    );
+  });
+
+  test('accepts URL form for stage', async () => {
+    setupCommonRemotes();
+    confirmResponse = true;
+    mockResponses.set('gh issue view 7 --repo owner/mirror', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        number: 7,
+        url: 'https://github.com/owner/mirror/issues/7',
+        title: 't',
+        body: '',
+        state: 'OPEN',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('gh issue create --repo up/repo', {
+      exitCode: 0,
+      stdout: 'https://github.com/up/repo/issues/40\n',
+      stderr: '',
+    });
+
+    try {
+      await issueCommand('stage', 'https://github.com/owner/mirror/issues/7');
+    } catch {
+      // ignore
+    }
+
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('gh issue view 7') && cmd.includes('--repo owner/mirror')
+      )
+    ).toBe(true);
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -235,6 +235,31 @@ describe('updateVenforkConfig', () => {
     expect(first.pulledPrs?.['upstream-pr/42']?.upstreamPrNumber).toBe(42);
   });
 
+  test('records and merges shippedIssues + pulledIssues', async () => {
+    const first = await updateVenforkConfig('/tmp/repo', {
+      shippedIssues: {
+        '7': {
+          internalIssueNumber: 7,
+          internalIssueUrl: 'https://github.com/owner/mirror/issues/7',
+          upstreamIssueNumber: 99,
+          upstreamIssueUrl: 'https://github.com/upstream/repo/issues/99',
+          shippedAt: '2026-04-28T10:00:00Z',
+        },
+      },
+      pulledIssues: {
+        '12': {
+          upstreamIssueNumber: 200,
+          upstreamIssueUrl: 'https://github.com/upstream/repo/issues/200',
+          internalIssueNumber: 12,
+          internalIssueUrl: 'https://github.com/owner/mirror/issues/12',
+          pulledAt: '2026-04-28T11:00:00Z',
+        },
+      },
+    });
+    expect(first.shippedIssues?.['7']?.upstreamIssueNumber).toBe(99);
+    expect(first.pulledIssues?.['12']?.upstreamIssueNumber).toBe(200);
+  });
+
   test('drops malformed shippedBranches entries during normalize', async () => {
     mockResponses.set(
       'git show FETCH_HEAD:.venfork/config.json',

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -105,6 +105,20 @@ describe('readVenforkConfigFromRepo', () => {
   });
 });
 
+const baseConfig = {
+  version: '1' as const,
+  publicForkUrl: 'git@github.com:test/public.git',
+  upstreamUrl: 'git@github.com:upstream/repo.git',
+};
+
+function mockReadResponse(config: unknown) {
+  return {
+    exitCode: 0,
+    stdout: JSON.stringify(config),
+    stderr: '',
+  };
+}
+
 describe('updateVenforkConfig', () => {
   test('merges schedule patch and writes updated config branch', async () => {
     const updated = await updateVenforkConfig('/tmp/repo', {
@@ -138,5 +152,106 @@ describe('updateVenforkConfig', () => {
     expect(writeFileCalls[writeFileCalls.length - 1].content).toContain(
       '"disabledWorkflows"'
     );
+  });
+
+  test('records and merges shippedBranches entries', async () => {
+    // First ship: insert one entry.
+    const first = await updateVenforkConfig('/tmp/repo', {
+      shippedBranches: {
+        'feat/auth': {
+          upstreamPrUrl: 'https://github.com/upstream/repo/pull/123',
+          head: 'abc1234',
+          shippedAt: '2026-04-28T10:00:00Z',
+          internalPrUrl: 'https://github.com/owner/mirror/pull/7',
+        },
+      },
+    });
+    expect(first.shippedBranches?.['feat/auth']?.upstreamPrUrl).toBe(
+      'https://github.com/upstream/repo/pull/123'
+    );
+
+    // Subsequent updates merge rather than replace.
+    mockResponses.set(
+      'git show FETCH_HEAD:.venfork/config.json',
+      mockReadResponse({
+        ...baseConfig,
+        shippedBranches: first.shippedBranches,
+      })
+    );
+
+    // Second ship: add another branch entry; existing entry preserved.
+    const second = await updateVenforkConfig('/tmp/repo', {
+      shippedBranches: {
+        'feat/api': {
+          upstreamPrUrl: 'https://github.com/upstream/repo/pull/456',
+          head: 'def5678',
+          shippedAt: '2026-04-28T11:00:00Z',
+        },
+      },
+    });
+    expect(Object.keys(second.shippedBranches ?? {}).sort()).toEqual([
+      'feat/api',
+      'feat/auth',
+    ]);
+
+    // Per-entry deletion via null.
+    mockResponses.set(
+      'git show FETCH_HEAD:.venfork/config.json',
+      mockReadResponse({
+        ...baseConfig,
+        shippedBranches: second.shippedBranches,
+      })
+    );
+    const third = await updateVenforkConfig('/tmp/repo', {
+      shippedBranches: { 'feat/auth': null },
+    });
+    expect(Object.keys(third.shippedBranches ?? {})).toEqual(['feat/api']);
+
+    // Whole-field clear.
+    mockResponses.set(
+      'git show FETCH_HEAD:.venfork/config.json',
+      mockReadResponse({
+        ...baseConfig,
+        shippedBranches: third.shippedBranches,
+      })
+    );
+    const fourth = await updateVenforkConfig('/tmp/repo', {
+      shippedBranches: null,
+    });
+    expect(fourth.shippedBranches).toBeUndefined();
+  });
+
+  test('records and merges pulledPrs entries with same semantics', async () => {
+    const first = await updateVenforkConfig('/tmp/repo', {
+      pulledPrs: {
+        'upstream-pr/42': {
+          upstreamPrNumber: 42,
+          upstreamPrUrl: 'https://github.com/upstream/repo/pull/42',
+          head: 'cafe1234',
+          lastSyncedAt: '2026-04-28T10:00:00Z',
+        },
+      },
+    });
+    expect(first.pulledPrs?.['upstream-pr/42']?.upstreamPrNumber).toBe(42);
+  });
+
+  test('drops malformed shippedBranches entries during normalize', async () => {
+    mockResponses.set(
+      'git show FETCH_HEAD:.venfork/config.json',
+      mockReadResponse({
+        ...baseConfig,
+        shippedBranches: {
+          good: {
+            upstreamPrUrl: 'https://github.com/u/r/pull/1',
+            head: 'aaa',
+            shippedAt: '2026-04-28T10:00:00Z',
+          },
+          // missing required fields → dropped
+          bad: { upstreamPrUrl: 'https://github.com/u/r/pull/2' },
+        } as never,
+      })
+    );
+    const updated = await updateVenforkConfig('/tmp/repo', {});
+    expect(Object.keys(updated.shippedBranches ?? {})).toEqual(['good']);
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -61,6 +61,13 @@ function getMockExecaResponse(command: string) {
   if (command.includes('git fetch origin venfork-config')) {
     return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
   }
+  if (command.includes('git rev-parse FETCH_HEAD')) {
+    return Promise.resolve({
+      exitCode: 0,
+      stdout: 'cafebabe1234567890abcdef\n',
+      stderr: '',
+    });
+  }
   if (command.includes('git show FETCH_HEAD:.venfork/config.json')) {
     return Promise.resolve({
       exitCode: 0,
@@ -278,5 +285,148 @@ describe('updateVenforkConfig', () => {
     );
     const updated = await updateVenforkConfig('/tmp/repo', {});
     expect(Object.keys(updated.shippedBranches ?? {})).toEqual(['good']);
+  });
+
+  test('writes config branch with --force-with-lease against the read sha', async () => {
+    mockResponses.set('git rev-parse FETCH_HEAD', {
+      exitCode: 0,
+      stdout: 'deadbeef0000000000000000\n',
+      stderr: '',
+    });
+
+    await updateVenforkConfig('/tmp/repo', {
+      shippedBranches: {
+        'feat/auth': {
+          upstreamPrUrl: 'https://github.com/u/r/pull/1',
+          head: 'aaa',
+          shippedAt: '2026-04-28T10:00:00Z',
+        },
+      },
+    });
+
+    // The push should use the SHA captured during the read, not a fresh
+    // ls-remote (which would race with concurrent writers).
+    const pushCalls = execaCalls.filter(
+      (cmd) =>
+        cmd.includes('git push') &&
+        cmd.includes('venfork-config:venfork-config')
+    );
+    expect(pushCalls.length).toBe(1);
+    expect(pushCalls[0]).toContain(
+      '--force-with-lease=venfork-config:deadbeef0000000000000000'
+    );
+  });
+
+  test('retries on stale-info lease failure and succeeds with fresh state', async () => {
+    // First push: lease failure (another venfork command got there first).
+    // Second push: succeeds.
+    let pushAttempt = 0;
+    mockResponses.set('git push', (cmd: string) => {
+      if (!cmd.includes('venfork-config:venfork-config')) {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      pushAttempt += 1;
+      if (pushAttempt === 1) {
+        return Promise.reject(
+          new Error(
+            '! [rejected] venfork-config -> venfork-config (stale info)'
+          )
+        );
+      }
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+
+    // Each fetch+rev-parse pair returns a different SHA so we can confirm
+    // the retry re-read.
+    let fetchCount = 0;
+    mockResponses.set('git rev-parse FETCH_HEAD', () => {
+      fetchCount += 1;
+      return Promise.resolve({
+        exitCode: 0,
+        stdout: fetchCount === 1 ? 'sha1\n' : 'sha2\n',
+        stderr: '',
+      });
+    });
+
+    const result = await updateVenforkConfig('/tmp/repo', {
+      shippedBranches: {
+        'feat/auth': {
+          upstreamPrUrl: 'https://github.com/u/r/pull/1',
+          head: 'aaa',
+          shippedAt: '2026-04-28T10:00:00Z',
+        },
+      },
+    });
+
+    expect(pushAttempt).toBe(2);
+    expect(fetchCount).toBeGreaterThanOrEqual(2); // re-read between attempts
+    expect(result.shippedBranches?.['feat/auth']?.upstreamPrUrl).toBe(
+      'https://github.com/u/r/pull/1'
+    );
+    // The successful retry leased against the second-read SHA.
+    const successfulPush = execaCalls
+      .filter(
+        (cmd) =>
+          cmd.includes('git push') &&
+          cmd.includes('venfork-config:venfork-config')
+      )
+      .pop();
+    expect(successfulPush).toContain('--force-with-lease=venfork-config:sha2');
+  });
+
+  test('throws after exhausting retries when every push hits stale-info', async () => {
+    let pushAttempt = 0;
+    mockResponses.set('git push', (cmd: string) => {
+      if (!cmd.includes('venfork-config:venfork-config')) {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      pushAttempt += 1;
+      return Promise.reject(
+        new Error('! [rejected] venfork-config -> venfork-config (stale info)')
+      );
+    });
+
+    await expect(
+      updateVenforkConfig('/tmp/repo', {
+        shippedBranches: {
+          'feat/auth': {
+            upstreamPrUrl: 'https://github.com/u/r/pull/1',
+            head: 'aaa',
+            shippedAt: '2026-04-28T10:00:00Z',
+          },
+        },
+      })
+    ).rejects.toThrow(/concurrent-write retries|stale info/i);
+
+    // Bounded at MAX_RETRIES = 3.
+    expect(pushAttempt).toBe(3);
+  });
+
+  test('does NOT retry on non-lease errors (e.g. auth failure)', async () => {
+    let pushAttempt = 0;
+    mockResponses.set('git push', (cmd: string) => {
+      if (!cmd.includes('venfork-config:venfork-config')) {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      pushAttempt += 1;
+      return Promise.reject(
+        new Error('fatal: Authentication failed for github.com')
+      );
+    });
+
+    await expect(
+      updateVenforkConfig('/tmp/repo', {
+        shippedBranches: {
+          'feat/auth': {
+            upstreamPrUrl: 'https://github.com/u/r/pull/1',
+            head: 'aaa',
+            shippedAt: '2026-04-28T10:00:00Z',
+          },
+        },
+      })
+    ).rejects.toThrow(/Authentication failed/);
+
+    // Only one push attempt — we don't retry auth failures.
+    expect(pushAttempt).toBe(1);
   });
 });

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -111,6 +111,111 @@ export async function pokeUpstream(
 }
 
 /**
+ * Creates a branch on `<UPSTREAM_OWNER>/<upstream>` with a new file commit
+ * via the GitHub contents API, then opens a PR from that branch into
+ * upstream's default branch. Returns the PR number + URL.
+ *
+ * Used by Tier 4 (pull-request) so the test owns an upstream PR it can
+ * also update later with `pushToUpstreamPrBranch`.
+ */
+export async function openUpstreamPr(args: {
+  branch: string;
+  filename: string;
+  content: string;
+  title: string;
+  body: string;
+  base: string;
+}): Promise<{ number: number; url: string }> {
+  // 1. Get base branch SHA so we can create the new ref.
+  const baseRef =
+    await $`gh api repos/${UPSTREAM_OWNER}/${names.upstream}/git/refs/heads/${args.base} --jq .object.sha`;
+  const baseSha = baseRef.stdout.trim();
+  // 2. Create the new branch ref pointing at base.
+  await $`gh api repos/${UPSTREAM_OWNER}/${names.upstream}/git/refs -X POST -f ref=refs/heads/${args.branch} -f sha=${baseSha}`;
+  // 3. PUT a file on that branch (creates a commit on it).
+  const b64 = Buffer.from(args.content, 'utf8').toString('base64');
+  await $`gh api repos/${UPSTREAM_OWNER}/${names.upstream}/contents/${args.filename} -X PUT -f message=${`e2e upstream PR commit ${args.filename}`} -f content=${b64} -f branch=${args.branch}`;
+  // 4. Open the PR.
+  const created =
+    await $`gh pr create --repo ${UPSTREAM_OWNER}/${names.upstream} --base ${args.base} --head ${args.branch} --title ${args.title} --body ${args.body}`;
+  const url = created.stdout.trim().split(/\s+/).pop() ?? '';
+  const numberMatch = url.match(/\/pull\/(\d+)/);
+  if (!numberMatch) {
+    throw new Error(`Could not parse upstream PR URL: ${url}`);
+  }
+  return { number: Number(numberMatch[1]), url };
+}
+
+/**
+ * Pushes another commit onto an existing upstream PR's branch via the
+ * contents API. Used by Tier 4 to verify `venfork sync upstream-pr/<n>`
+ * picks up new commits.
+ */
+export async function pushToUpstreamPrBranch(args: {
+  branch: string;
+  filename: string;
+  content: string;
+}): Promise<void> {
+  const apiPath = `repos/${UPSTREAM_OWNER}/${names.upstream}/contents/${args.filename}`;
+  const b64 = Buffer.from(args.content, 'utf8').toString('base64');
+  const existing =
+    await ghQuiet`gh api ${apiPath}?ref=${args.branch} --jq .sha`;
+  const message = `e2e PR update ${args.filename}`;
+  if (existing.exitCode === 0 && existing.stdout.trim()) {
+    const sha = existing.stdout.trim();
+    await $`gh api ${apiPath} -X PUT -f message=${message} -f content=${b64} -f branch=${args.branch} -f sha=${sha}`;
+  } else {
+    await $`gh api ${apiPath} -X PUT -f message=${message} -f content=${b64} -f branch=${args.branch}`;
+  }
+}
+
+/**
+ * Creates an issue on the given GitHub repo via gh and returns
+ * { number, url }.
+ */
+export async function createIssueOnRepo(args: {
+  owner: string;
+  repo: string;
+  title: string;
+  body: string;
+}): Promise<{ number: number; url: string }> {
+  const result =
+    await $`gh issue create --repo ${args.owner}/${args.repo} --title ${args.title} --body ${args.body}`;
+  const url = result.stdout.trim().split(/\s+/).pop() ?? '';
+  const match = url.match(/\/issues\/(\d+)/);
+  if (!match) {
+    throw new Error(`Could not parse issue URL: ${url}`);
+  }
+  return { number: Number(match[1]), url };
+}
+
+/**
+ * Reads an issue's metadata via gh.
+ */
+export async function getIssueMeta(args: {
+  owner: string;
+  repo: string;
+  number: number;
+}): Promise<{ title: string; body: string; state: string; url: string }> {
+  const result =
+    await $`gh issue view ${args.number} --repo ${args.owner}/${args.repo} --json title,body,state,url`;
+  return JSON.parse(result.stdout);
+}
+
+/**
+ * Reads a PR's metadata + body via gh.
+ */
+export async function getPrMeta(args: {
+  owner: string;
+  repo: string;
+  number: number;
+}): Promise<{ title: string; body: string; state: string; url: string }> {
+  const result =
+    await $`gh pr view ${args.number} --repo ${args.owner}/${args.repo} --json title,body,state,url`;
+  return JSON.parse(result.stdout);
+}
+
+/**
  * Returns the SHA at the tip of `branch` for `<owner>/<repo>`.
  */
 export async function getDefaultBranchSha(

--- a/tests/e2e/sync-flow.test.ts
+++ b/tests/e2e/sync-flow.test.ts
@@ -457,17 +457,22 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
       env: { VENFORK_NONINTERACTIVE: '1' },
     });
 
-    // Find the upstream issue and verify body redaction.
-    const list =
-      await $`gh issue list --repo ${UPSTREAM_OWNER}/${names.upstream} --state all --search ${'Safari rendering'} --json number,url,body --limit 5`;
-    const upstreamIssues = JSON.parse(list.stdout) as Array<{
-      number: number;
-      url: string;
-      body: string;
-    }>;
-    const upstreamIssue = upstreamIssues.find((i) =>
-      i.body.includes('Public bug summary')
-    );
+    // Find the upstream issue. Don't use gh's `--search` — its index is
+    // eventually consistent. Even the plain list endpoint has cache lag
+    // for freshly-created issues, so retry a few times.
+    type IssueListEntry = { number: number; url: string; body: string };
+    let upstreamIssue: IssueListEntry | undefined;
+    for (let attempt = 0; attempt < 5 && !upstreamIssue; attempt += 1) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
+      const list =
+        await $`gh issue list --repo ${UPSTREAM_OWNER}/${names.upstream} --state all --json number,url,body --limit 20`;
+      const upstreamIssues = JSON.parse(list.stdout) as IssueListEntry[];
+      upstreamIssue = upstreamIssues.find((i) =>
+        i.body.includes('Public bug summary')
+      );
+    }
     expect(upstreamIssue).toBeDefined();
     expect(upstreamIssue?.body).not.toContain('Client X');
     expect(upstreamIssue?.body).not.toContain('venfork:internal');
@@ -487,16 +492,20 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
 
     // The mirror should now have an issue whose title carries the
     // [upstream #N] prefix and whose body references the upstream URL.
-    const mirrorList =
-      await $`gh issue list --repo ${GITHUB_ORG}/${names.mirrorBare} --state all --search ${`upstream #${upstreamReport.number}`} --json number,title,body --limit 5`;
-    const mirrorIssues = JSON.parse(mirrorList.stdout) as Array<{
-      number: number;
-      title: string;
-      body: string;
-    }>;
-    const mirrorIssue = mirrorIssues.find((i) =>
-      i.title.includes(`upstream #${upstreamReport.number}`)
-    );
+    // Same retry-with-cache-lag reasoning as above.
+    type MirrorIssue = { number: number; title: string; body: string };
+    let mirrorIssue: MirrorIssue | undefined;
+    for (let attempt = 0; attempt < 5 && !mirrorIssue; attempt += 1) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+      }
+      const mirrorList =
+        await $`gh issue list --repo ${GITHUB_ORG}/${names.mirrorBare} --state all --json number,title,body --limit 20`;
+      const mirrorIssues = JSON.parse(mirrorList.stdout) as MirrorIssue[];
+      mirrorIssue = mirrorIssues.find((i) =>
+        i.title.includes(`upstream #${upstreamReport.number}`)
+      );
+    }
     expect(mirrorIssue).toBeDefined();
     expect(mirrorIssue?.body).toContain(upstreamReport.url);
 

--- a/tests/e2e/sync-flow.test.ts
+++ b/tests/e2e/sync-flow.test.ts
@@ -4,6 +4,7 @@ import { $ } from 'execa';
 import { readVenforkConfigFromRepo } from '../../src/config.js';
 import {
   cleanupAll,
+  createIssueOnRepo,
   createUpstreamRepo,
   dirExists,
   ensureDeleteRepoScope,
@@ -11,12 +12,16 @@ import {
   ensureGhAuth,
   GITHUB_ORG,
   getDefaultBranchSha,
+  getIssueMeta,
+  getPrMeta,
   getPushToken,
   getRepoDefaultBranch,
   listCommitMessages,
   localMirrorPath,
   names,
+  openUpstreamPr,
   pokeUpstream,
+  pushToUpstreamPrBranch,
   REPO_ROOT,
   RUN_ID,
   readWorkflowFromOrigin,
@@ -303,4 +308,192 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
     },
     1_500_000
   );
+
+  test('tier 3: stage --pr opens upstream PR with internal body redacted', async () => {
+    const defaultBranch = await getRepoDefaultBranch(
+      UPSTREAM_OWNER,
+      names.upstream
+    );
+    const featureBranch = `feat-${RUN_ID}`;
+
+    // Create a feature branch on the local mirror clone with one commit.
+    await $({
+      cwd: localMirrorPath,
+    })`git checkout -b ${featureBranch}`;
+    await fs.writeFile(`${localMirrorPath}/feature.txt`, `feature ${RUN_ID}\n`);
+    await $({
+      cwd: localMirrorPath,
+    })`git -c user.name=e2e -c user.email=e2e@local add feature.txt`;
+    await $({
+      cwd: localMirrorPath,
+    })`git -c user.name=e2e -c user.email=e2e@local commit -m ${'feat: add feature.txt'}`;
+    await $({ cwd: localMirrorPath })`git push origin ${featureBranch}`;
+
+    // Open an internal review PR on the mirror with body containing a
+    // redaction block.
+    const internalBody = [
+      'Public summary: adds feature.txt to demonstrate ship.',
+      '',
+      '<!-- venfork:internal -->',
+      'Internal note: client X requires this for compliance ticket Z.',
+      '<!-- /venfork:internal -->',
+      '',
+      'Implementation notes intended for upstream maintainers.',
+    ].join('\n');
+    await $`gh pr create --repo ${GITHUB_ORG}/${names.mirrorBare} --base ${defaultBranch} --head ${featureBranch} --title ${'feat: add feature.txt'} --body ${internalBody}`;
+
+    // Drive `venfork stage --pr`, auto-confirming the prompt.
+    await runVenfork(['stage', featureBranch, '--pr', '--draft'], {
+      cwd: localMirrorPath,
+      input: 'y\n',
+    });
+
+    // Find the upstream PR and verify body translation + draft state.
+    const list =
+      await $`gh pr list --repo ${UPSTREAM_OWNER}/${names.upstream} --head ${GITHUB_ORG}:${featureBranch} --state all --json number,url,body,isDraft --limit 1`;
+    const prs = JSON.parse(list.stdout) as Array<{
+      number: number;
+      url: string;
+      body: string;
+      isDraft: boolean;
+    }>;
+    expect(prs.length).toBe(1);
+    const upstreamPr = prs[0];
+    expect(upstreamPr.body).not.toContain('Internal note');
+    expect(upstreamPr.body).not.toContain('venfork:internal');
+    expect(upstreamPr.body).toContain('Public summary');
+    expect(upstreamPr.body).toContain('Upstreamed from internal review');
+    expect(upstreamPr.isDraft).toBe(true);
+  }, 300_000);
+
+  test('tier 4: pull-request imports an upstream PR; sync refreshes it', async () => {
+    const defaultBranch = await getRepoDefaultBranch(
+      UPSTREAM_OWNER,
+      names.upstream
+    );
+
+    // Open a PR on upstream by creating a branch directly there.
+    const upstreamPrBranch = `upstream-feat-${RUN_ID}`;
+    const opened = await openUpstreamPr({
+      branch: upstreamPrBranch,
+      filename: `upstream-${RUN_ID}.md`,
+      content: `original content ${RUN_ID}\n`,
+      title: `e2e upstream PR ${RUN_ID}`,
+      body: 'Body of an upstream PR for e2e.',
+      base: defaultBranch,
+    });
+
+    // Pull it into the mirror.
+    await runVenfork(['pull-request', String(opened.number)], {
+      cwd: localMirrorPath,
+    });
+
+    // Verify the local + mirror branch exist with the imported head.
+    const localBranch = `upstream-pr/${opened.number}`;
+    const initialLocalHead = (
+      await $({
+        cwd: localMirrorPath,
+      })`git rev-parse ${localBranch}`
+    ).stdout.trim();
+    const mirrorHead = await getDefaultBranchSha(
+      GITHUB_ORG,
+      names.mirrorBare,
+      localBranch
+    );
+    expect(mirrorHead).toBe(initialLocalHead);
+
+    // Update the upstream PR with another commit.
+    await pushToUpstreamPrBranch({
+      branch: upstreamPrBranch,
+      filename: `upstream-${RUN_ID}.md`,
+      content: `updated content ${RUN_ID}\n`,
+    });
+
+    // venfork sync <branch> should refresh the local + mirror branch.
+    await runVenfork(['sync', localBranch], { cwd: localMirrorPath });
+
+    const refreshedLocalHead = (
+      await $({
+        cwd: localMirrorPath,
+      })`git rev-parse ${localBranch}`
+    ).stdout.trim();
+    expect(refreshedLocalHead).not.toBe(initialLocalHead);
+    const refreshedMirrorHead = await getDefaultBranchSha(
+      GITHUB_ORG,
+      names.mirrorBare,
+      localBranch
+    );
+    expect(refreshedMirrorHead).toBe(refreshedLocalHead);
+  }, 300_000);
+
+  test('tier 5: issue stage + issue pull round-trip through gh', async () => {
+    // Create an internal issue on the mirror with a redaction block.
+    const internalBody = [
+      'Public bug summary: feature.txt does not load in Safari.',
+      '',
+      '<!-- venfork:internal -->',
+      'Client X needs a fix before launch on date Y.',
+      '<!-- /venfork:internal -->',
+    ].join('\n');
+    const internal = await createIssueOnRepo({
+      owner: GITHUB_ORG,
+      repo: names.mirrorBare,
+      title: 'Bug: Safari rendering',
+      body: internalBody,
+    });
+
+    // Stage the internal issue upstream.
+    await runVenfork(['issue', 'stage', String(internal.number)], {
+      cwd: localMirrorPath,
+      input: 'y\n',
+    });
+
+    // Find the upstream issue and verify body redaction.
+    const list =
+      await $`gh issue list --repo ${UPSTREAM_OWNER}/${names.upstream} --state all --search ${'Safari rendering'} --json number,url,body --limit 5`;
+    const upstreamIssues = JSON.parse(list.stdout) as Array<{
+      number: number;
+      url: string;
+      body: string;
+    }>;
+    const upstreamIssue = upstreamIssues.find((i) =>
+      i.body.includes('Public bug summary')
+    );
+    expect(upstreamIssue).toBeDefined();
+    expect(upstreamIssue?.body).not.toContain('Client X');
+    expect(upstreamIssue?.body).not.toContain('venfork:internal');
+
+    // Pull a different upstream issue back into the mirror.
+    const upstreamReport = await createIssueOnRepo({
+      owner: UPSTREAM_OWNER,
+      repo: names.upstream,
+      title: 'Upstream-reported bug',
+      body: 'Reported by an external user.',
+    });
+
+    await runVenfork(['issue', 'pull', String(upstreamReport.number)], {
+      cwd: localMirrorPath,
+      input: 'y\n',
+    });
+
+    // The mirror should now have an issue whose title carries the
+    // [upstream #N] prefix and whose body references the upstream URL.
+    const mirrorList =
+      await $`gh issue list --repo ${GITHUB_ORG}/${names.mirrorBare} --state all --search ${`upstream #${upstreamReport.number}`} --json number,title,body --limit 5`;
+    const mirrorIssues = JSON.parse(mirrorList.stdout) as Array<{
+      number: number;
+      title: string;
+      body: string;
+    }>;
+    const mirrorIssue = mirrorIssues.find((i) =>
+      i.title.includes(`upstream #${upstreamReport.number}`)
+    );
+    expect(mirrorIssue).toBeDefined();
+    expect(mirrorIssue?.body).toContain(upstreamReport.url);
+
+    // Suppress unused-var warnings for helpers we leave in place for
+    // future debugging hooks.
+    void getIssueMeta;
+    void getPrMeta;
+  }, 300_000);
 });

--- a/tests/e2e/sync-flow.test.ts
+++ b/tests/e2e/sync-flow.test.ts
@@ -342,10 +342,11 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
     ].join('\n');
     await $`gh pr create --repo ${GITHUB_ORG}/${names.mirrorBare} --base ${defaultBranch} --head ${featureBranch} --title ${'feat: add feature.txt'} --body ${internalBody}`;
 
-    // Drive `venfork stage --pr`, auto-confirming the prompt.
+    // Drive `venfork stage --pr`, auto-confirming via env var (clack's
+    // confirm doesn't reliably accept piped `y\n` in non-TTY mode).
     await runVenfork(['stage', featureBranch, '--pr', '--draft'], {
       cwd: localMirrorPath,
-      input: 'y\n',
+      env: { VENFORK_NONINTERACTIVE: '1' },
     });
 
     // Find the upstream PR and verify body translation + draft state.
@@ -445,7 +446,7 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
     // Stage the internal issue upstream.
     await runVenfork(['issue', 'stage', String(internal.number)], {
       cwd: localMirrorPath,
-      input: 'y\n',
+      env: { VENFORK_NONINTERACTIVE: '1' },
     });
 
     // Find the upstream issue and verify body redaction.
@@ -473,7 +474,7 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
 
     await runVenfork(['issue', 'pull', String(upstreamReport.number)], {
       cwd: localMirrorPath,
-      input: 'y\n',
+      env: { VENFORK_NONINTERACTIVE: '1' },
     });
 
     // The mirror should now have an issue whose title carries the

--- a/tests/e2e/sync-flow.test.ts
+++ b/tests/e2e/sync-flow.test.ts
@@ -349,17 +349,25 @@ e2eDescribe('venfork e2e — scheduled sync flow', () => {
       env: { VENFORK_NONINTERACTIVE: '1' },
     });
 
-    // Find the upstream PR and verify body translation + draft state.
+    // Find the upstream PR. gh's --head filter on cross-repo PRs is
+    // unreliable, so list all PRs and filter by headRefName in JS.
     const list =
-      await $`gh pr list --repo ${UPSTREAM_OWNER}/${names.upstream} --head ${GITHUB_ORG}:${featureBranch} --state all --json number,url,body,isDraft --limit 1`;
+      await $`gh pr list --repo ${UPSTREAM_OWNER}/${names.upstream} --state all --json number,url,body,isDraft,headRefName,headRepositoryOwner --limit 20`;
     const prs = JSON.parse(list.stdout) as Array<{
       number: number;
       url: string;
       body: string;
       isDraft: boolean;
+      headRefName: string;
+      headRepositoryOwner?: { login: string };
     }>;
-    expect(prs.length).toBe(1);
-    const upstreamPr = prs[0];
+    const upstreamPr = prs.find(
+      (pr) =>
+        pr.headRefName === featureBranch &&
+        (pr.headRepositoryOwner?.login ?? '') === GITHUB_ORG
+    );
+    expect(upstreamPr).toBeDefined();
+    if (!upstreamPr) return;
     expect(upstreamPr.body).not.toContain('Internal note');
     expect(upstreamPr.body).not.toContain('venfork:internal');
     expect(upstreamPr.body).toContain('Public summary');

--- a/tests/issue-args.test.ts
+++ b/tests/issue-args.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { parseIssueCliArgs } from '../src/issue-args.js';
+
+describe('parseIssueCliArgs', () => {
+  test('parses `stage <n>`', () => {
+    const parsed = parseIssueCliArgs(['stage', '7']);
+    expect(parsed.action).toBe('stage');
+    expect(parsed.target).toBe('7');
+    expect(parsed.title).toBeUndefined();
+  });
+
+  test('parses `pull <n>`', () => {
+    const parsed = parseIssueCliArgs(['pull', '1234']);
+    expect(parsed.action).toBe('pull');
+    expect(parsed.target).toBe('1234');
+  });
+
+  test('parses --title value form', () => {
+    const parsed = parseIssueCliArgs(['stage', '7', '--title', 'Override']);
+    expect(parsed.title).toBe('Override');
+  });
+
+  test('parses --title= form', () => {
+    const parsed = parseIssueCliArgs(['stage', '7', '--title=Override']);
+    expect(parsed.title).toBe('Override');
+  });
+
+  test('throws on unknown action', () => {
+    expect(() => parseIssueCliArgs(['burn', '7'])).toThrow(
+      'Unknown issue action'
+    );
+  });
+
+  test('throws when --title has no value', () => {
+    expect(() => parseIssueCliArgs(['stage', '7', '--title'])).toThrow(
+      '--title requires a value'
+    );
+  });
+});

--- a/tests/pull-request-args.test.ts
+++ b/tests/pull-request-args.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { parsePullRequestCliArgs } from '../src/pull-request-args.js';
+
+describe('parsePullRequestCliArgs', () => {
+  test('parses positional pr number', () => {
+    const parsed = parsePullRequestCliArgs(['1234']);
+    expect(parsed.pr).toBe('1234');
+    expect(parsed.push).toBe(true);
+    expect(parsed.branchName).toBeUndefined();
+  });
+
+  test('parses positional pr URL', () => {
+    const parsed = parsePullRequestCliArgs([
+      'https://github.com/owner/repo/pull/42',
+    ]);
+    expect(parsed.pr).toBe('https://github.com/owner/repo/pull/42');
+  });
+
+  test('--no-push opts out of pushing to mirror', () => {
+    const parsed = parsePullRequestCliArgs(['42', '--no-push']);
+    expect(parsed.push).toBe(false);
+  });
+
+  test('--branch-name value form', () => {
+    const parsed = parsePullRequestCliArgs([
+      '42',
+      '--branch-name',
+      'review/upstream-42',
+    ]);
+    expect(parsed.branchName).toBe('review/upstream-42');
+  });
+
+  test('--branch-name= form', () => {
+    const parsed = parsePullRequestCliArgs([
+      '42',
+      '--branch-name=review/upstream-42',
+    ]);
+    expect(parsed.branchName).toBe('review/upstream-42');
+  });
+
+  test('throws when --branch-name has no value', () => {
+    expect(() => parsePullRequestCliArgs(['42', '--branch-name'])).toThrow(
+      '--branch-name requires a value'
+    );
+  });
+});

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { stripInternalBlocks } from '../src/commands.js';
+
+describe('stripInternalBlocks', () => {
+  test('removes a single block', () => {
+    const input =
+      'pub<!-- venfork:internal -->priv<!-- /venfork:internal -->lic';
+    expect(stripInternalBlocks(input)).toBe('public');
+  });
+
+  test('removes multiple sibling blocks', () => {
+    const input =
+      'A<!-- venfork:internal -->B<!-- /venfork:internal -->C<!-- venfork:internal -->D<!-- /venfork:internal -->E';
+    expect(stripInternalBlocks(input)).toBe('ACE');
+  });
+
+  test('removes properly-nested blocks (inner private leaks would be a bug)', () => {
+    // The iterative-regex approach Copilot flagged would leave behind
+    // "AD<!-- /venfork:internal -->E" here. The depth-tracking pass
+    // collapses both pairs and leaves only "AE".
+    const input =
+      'A<!-- venfork:internal -->B<!-- venfork:internal -->C<!-- /venfork:internal -->D<!-- /venfork:internal -->E';
+    expect(stripInternalBlocks(input)).toBe('AE');
+  });
+
+  test('tolerates whitespace and missing whitespace inside markers', () => {
+    const noSpaces = 'A<!--venfork:internal-->B<!--/venfork:internal-->C';
+    const extraSpaces =
+      'A<!--   venfork:internal   -->B<!--   /venfork:internal   -->C';
+    expect(stripInternalBlocks(noSpaces)).toBe('AC');
+    expect(stripInternalBlocks(extraSpaces)).toBe('AC');
+  });
+
+  test('handles content with no markers verbatim', () => {
+    const input = 'just public text\nwith newlines\n';
+    expect(stripInternalBlocks(input)).toBe(input);
+  });
+
+  test('drops a dangling close marker without consuming surrounding content', () => {
+    const input = 'pub<!-- /venfork:internal -->lic';
+    expect(stripInternalBlocks(input)).toBe('public');
+  });
+
+  test('drops content from an unmatched open marker to end-of-input (fail-safe)', () => {
+    // A typo'd close marker shouldn't leak the intended-private content
+    // — better to drop too much than to publish secrets.
+    const input = 'public<!-- venfork:internal -->oops no close';
+    expect(stripInternalBlocks(input)).toBe('public');
+  });
+
+  test('preserves multi-line content around blocks', () => {
+    const input = [
+      'Line 1',
+      'Line 2',
+      '<!-- venfork:internal -->',
+      'redacted line',
+      '<!-- /venfork:internal -->',
+      'Line 3',
+    ].join('\n');
+    const result = stripInternalBlocks(input);
+    expect(result).toContain('Line 1');
+    expect(result).toContain('Line 2');
+    expect(result).toContain('Line 3');
+    expect(result).not.toContain('redacted line');
+    expect(result).not.toContain('venfork:internal');
+  });
+
+  test('handles repeated calls without leaking regex state', () => {
+    // The internal regexes use the `g` flag; the parser must reset
+    // lastIndex so a second call doesn't pick up where the first left off.
+    const input = 'A<!-- venfork:internal -->B<!-- /venfork:internal -->C';
+    expect(stripInternalBlocks(input)).toBe('AC');
+    expect(stripInternalBlocks(input)).toBe('AC');
+    expect(stripInternalBlocks(input)).toBe('AC');
+  });
+});

--- a/tests/stage-args.test.ts
+++ b/tests/stage-args.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'bun:test';
+import { parseStageCliArgs } from '../src/stage-args.js';
+
+describe('parseStageCliArgs', () => {
+  test('parses positional branch with no flags', () => {
+    const parsed = parseStageCliArgs(['feat/auth']);
+    expect(parsed.branch).toBe('feat/auth');
+    expect(parsed.createPr).toBe(false);
+    expect(parsed.draft).toBe(false);
+    expect(parsed.title).toBeUndefined();
+    expect(parsed.base).toBeUndefined();
+  });
+
+  test('--pr opts in to upstream PR creation', () => {
+    const parsed = parseStageCliArgs(['feat/auth', '--pr']);
+    expect(parsed.branch).toBe('feat/auth');
+    expect(parsed.createPr).toBe(true);
+    expect(parsed.draft).toBe(false);
+  });
+
+  test('--draft implies --pr', () => {
+    const parsed = parseStageCliArgs(['feat/auth', '--draft']);
+    expect(parsed.createPr).toBe(true);
+    expect(parsed.draft).toBe(true);
+  });
+
+  test('parses --title and --base value forms', () => {
+    const parsed = parseStageCliArgs([
+      'feat/auth',
+      '--pr',
+      '--title',
+      'Add auth',
+      '--base',
+      'develop',
+    ]);
+    expect(parsed.title).toBe('Add auth');
+    expect(parsed.base).toBe('develop');
+  });
+
+  test('parses --title= and --base= forms', () => {
+    const parsed = parseStageCliArgs([
+      'feat/auth',
+      '--pr',
+      '--title=Add auth',
+      '--base=develop',
+    ]);
+    expect(parsed.title).toBe('Add auth');
+    expect(parsed.base).toBe('develop');
+  });
+
+  test('throws when --title has no value', () => {
+    expect(() => parseStageCliArgs(['feat/auth', '--pr', '--title'])).toThrow(
+      '--title requires a value'
+    );
+  });
+
+  test('throws when --title= is empty', () => {
+    expect(() => parseStageCliArgs(['feat/auth', '--pr', '--title='])).toThrow(
+      '--title requires a value'
+    );
+  });
+
+  test('throws when --base has no value', () => {
+    expect(() => parseStageCliArgs(['feat/auth', '--pr', '--base'])).toThrow(
+      '--base requires a value'
+    );
+  });
+
+  test('flag order does not matter; positional can come last', () => {
+    const parsed = parseStageCliArgs(['--pr', '--draft', 'feat/auth']);
+    expect(parsed.branch).toBe('feat/auth');
+    expect(parsed.createPr).toBe(true);
+    expect(parsed.draft).toBe(true);
+  });
+});

--- a/tests/stage-args.test.ts
+++ b/tests/stage-args.test.ts
@@ -72,4 +72,42 @@ describe('parseStageCliArgs', () => {
     expect(parsed.createPr).toBe(true);
     expect(parsed.draft).toBe(true);
   });
+
+  test('--internal-pr <n> sets internalPrNumber', () => {
+    const parsed = parseStageCliArgs([
+      'feat/auth',
+      '--pr',
+      '--internal-pr',
+      '42',
+    ]);
+    expect(parsed.internalPrNumber).toBe(42);
+  });
+
+  test('--internal-pr=<n> form', () => {
+    const parsed = parseStageCliArgs(['feat/auth', '--pr', '--internal-pr=42']);
+    expect(parsed.internalPrNumber).toBe(42);
+  });
+
+  test('throws when --internal-pr is not a positive integer', () => {
+    expect(() =>
+      parseStageCliArgs(['feat/auth', '--pr', '--internal-pr', 'abc'])
+    ).toThrow('--internal-pr requires a positive integer');
+    expect(() =>
+      parseStageCliArgs(['feat/auth', '--pr', '--internal-pr', '0'])
+    ).toThrow('--internal-pr requires a positive integer');
+  });
+
+  test('--no-update-existing flips the body re-sync default', () => {
+    const parsed = parseStageCliArgs([
+      'feat/auth',
+      '--pr',
+      '--no-update-existing',
+    ]);
+    expect(parsed.noUpdateExisting).toBe(true);
+  });
+
+  test('noUpdateExisting defaults to false', () => {
+    const parsed = parseStageCliArgs(['feat/auth', '--pr']);
+    expect(parsed.noUpdateExisting).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

Closes the round-trip between internal review on the private mirror and upstream PR/issue activity. Same use case in two directions:

- **Push direction**: `venfork stage <branch> --pr` opens the upstream PR using the internal-mirror review's body (with `<!-- venfork:internal -->...<!-- /venfork:internal -->` blocks redacted) and records the linkage.
- **Pull direction**: `venfork pull-request <pr>` brings a third-party upstream PR's commits into the mirror as `upstream-pr/<n>` for internal review. `venfork sync <branch>` refreshes pulled branches from `pull/<n>/head`.
- **Issues**: `venfork issue stage/pull` does the same shape for issues — body redaction in stage, internal-issue creation with `[upstream #N]` prefix in pull.

Default `venfork stage` (no `--pr`) is byte-for-byte identical to 0.5.0 — no script breakage.

## Commands

- `venfork stage <branch> [--pr] [--draft] [--title <text>] [--base <branch>] [--internal-pr <n>] [--no-update-existing]`
- `venfork pull-request <pr-number-or-url> [--branch-name <override>] [--no-push]`
- `venfork issue <stage|pull> <number-or-url> [--title <text>]`
- `venfork sync <branch>` — extended; when `<branch>` matches a `pulledPrs` entry or the `upstream-pr/<n>` convention, refreshes from `pull/<n>/head` instead of running the default-branch +1-commit flow.

## Config schema additions

`VenforkConfig` gains four branch-keyed maps:
- `shippedBranches[<branch>]` — recorded by `stage --pr`
- `pulledPrs[<branch>]` — recorded by `pull-request`
- `shippedIssues[<internal-#>]` — recorded by `issue stage`
- `pulledIssues[<internal-#>]` — recorded by `issue pull`

Same per-entry merge + null-clear semantics, same per-entry validators that drop malformed records during normalize.

## Environment variable

`VENFORK_NONINTERACTIVE=1` auto-confirms `stage --pr` / `issue stage|pull` prompts. Useful for CI and scripts. The setup-time personal-account confirmation is intentionally **not** bypassed.

## Test plan

- [x] `bun test` — **225 pass / 6 skip / 0 fail** (was 175 on main → +50 new tests across config schema, args parsers, command flows, and review-fix regression coverage).
- [x] `bunx biome check .` — clean.
- [x] `bun run build` — OK (0.38 MB dist).
- [x] `bun run test:e2e` against real GitHub:
  - Tier 1: setup → schedule → upstream poke → local sync (existing).
  - Tier 3: `stage --pr` opens upstream PR with internal body redacted; `--draft` honoured.
  - Tier 4: `pull-request` imports an upstream PR; `sync upstream-pr/<n>` refreshes after a new upstream commit.
  - Tier 5: `issue stage` round-trip with redaction; `issue pull` with `[upstream #N]` prefix and back-reference.
  - **4 pass / 2 skip / 0 fail / 86s.** Cleanup verified — zero leaked repos under either owner, `tmp/` empty.

## Self-review fixes baked in

A self-review surfaced 11 issues; all are fixed in commit `634a313`. Notable ones:

- Synthetic upstream-PR body (when no internal review PR exists) is now generated from `git log --oneline upstream/<default>..<branch>` instead of "please add a description" placeholder text.
- `gh pr create` "already exists" path now follows up with `gh pr edit --body-file -` to refresh the upstream body — addresses internal review feedback re-published upstream. `--no-update-existing` opts out.
- `--internal-pr <n>` flag pins a specific internal PR (skips most-recent-open lookup).
- Redaction regex iterates until no markers remain — nested `<!-- venfork:internal -->` blocks now redact correctly.
- URL mismatches now throw instead of silently using the upstream remote.
- `pullRequestCommand` only records the `pulledPrs` linkage when the mirror push actually succeeded.
- `writeConfigBranch` switches `--force` → explicit `--force-with-lease=venfork-config:<sha>` (read via `git ls-remote`) for concurrency safety.
- `venfork status` now surfaces all four linkage maps.

Two bugs were caught by running the live e2e against real GitHub (clack confirms swallowing `y\n` over piped stdin; `gh pr list --state open` collapsed into one execa arg). Both are fixed; the corresponding regression tests are in `tests/commands.test.ts`.

## Notes for after merge

release-please will queue 0.5.0 → 0.6.0 (one `feat:` commit drives the minor bump; the rest are `fix:`/`test:`/`refactor:` and just append to the changelog).

Followups not in this PR (worth filing as issues):
- `venfork status` could optionally hit `gh pr view` per `shippedBranches` entry to show *current* upstream state. Skipped here for big-map performance.
- `--internal-pr <URL>` form (number-only for now).
- Optimistic-concurrency retry loop on `--force-with-lease` failures — currently fail-loud + user retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)