### PR TITLE
feat: add --no-public mode (skip the public-fork hop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ venfork sync upstream-pr/1234
 
 ## Commands
 
-### `venfork setup <upstream> [name] [--org <organization>] [--fork-name <repo>]`
+### `venfork setup <upstream> [name] [--org <organization>] [--fork-name <repo>] [--no-public]`
 
 Creates the complete vendor workflow setup:
 
@@ -113,13 +113,15 @@ Creates the complete vendor workflow setup:
 
 **`--fork-name`** sets the **public fork’s repository name** under your chosen owner/org (passed through to `gh repo fork --fork-name`). Use this when **upstream already lives under the same org** you pass to `--org`: GitHub cannot create a second repo with the same name, so the fork must use a different name (e.g. `my-lib-public` while upstream is `my-lib`).
 
+**`--no-public`** skips the public-fork hop entirely. Only `origin` (private mirror) and `upstream` are configured; `venfork stage` later pushes branches **directly to upstream** and `--pr` opens an intra-upstream PR. Use this when you **own the upstream** repo (no client to hide work from) — it removes a redundant fork-and-stage round-trip. Mutually exclusive with `--fork-name`.
+
 **What it creates:**
 - **Private mirror** (`yourname/project-private` or `org/project-private`) - For internal work
-- **Public fork** (`yourname/project` or `org/project`, or the name from **`--fork-name`**) - For staging to upstream
-- **Config branch** (`venfork-config`) - Stores remote URLs for easy team cloning
-- **Local clone** with three remotes configured:
+- **Public fork** (`yourname/project` or `org/project`, or the name from **`--fork-name`**) - For staging to upstream *(skipped with `--no-public`)*
+- **Config branch** (`venfork-config`) - Stores remote URLs (and `mode: 'no-public'` when applicable) for easy team cloning
+- **Local clone** with remotes configured:
   - `origin` → private mirror (default push/pull)
-  - `public` → public fork (for staging)
+  - `public` → public fork (for staging) *(omitted with `--no-public`)*
   - `upstream` → original repo (read-only, push disabled)
 
 **Arguments:**
@@ -127,6 +129,7 @@ Creates the complete vendor workflow setup:
 - `name` - (Optional) Name for private mirror repo (default: `{repo}-private`)
 - `--org <organization>` - (Optional) Create repos under organization instead of personal account
 - `--fork-name <repo>` - (Optional) Public fork repo name under that org/user (default: same basename as upstream)
+- `--no-public` - (Optional) Skip the public-fork hop; stage pushes directly to upstream
 
 **Examples:**
 ```bash
@@ -152,6 +155,11 @@ venfork setup my-org/foo my-foo-private --org my-org --fork-name foo-public
 
 # Shorthand also works with --org + --fork-name (equivalent to git@github.com:firebase/extensions.git)
 venfork setup firebase/extensions firebase-extensions-private --org invertase --fork-name firebase-extensions
+
+# Upstream is already in your org and there is no public-vs-private audience to maintain
+# — skip the fork hop entirely. `stage` will push directly to my-org/foo and open an intra-repo PR.
+venfork setup my-org/foo my-foo-private --org my-org --no-public
+# Creates: my-org/my-foo-private (private), upstream = my-org/foo. No public fork.
 ```
 
 **Re-running setup (repos already on GitHub):** Run the same command again if you need a fresh local clone, remote fixes, or an updated `venfork-config` branch. Venfork uses `gh repo view` to detect a public fork or private mirror that already exists when `gh repo fork` or `gh repo create` fails, then:
@@ -164,7 +172,7 @@ venfork setup firebase/extensions firebase-extensions-private --org invertase --
 
 Pure failures (for example name taken by a **different** repo) still abort setup. If recovery sync stops due to divergent default branches, fix or move those commits, then run **`venfork sync`** again from inside the private mirror.
 
-### `venfork clone <vendor-repo>`
+### `venfork clone <vendor-repo> [--no-public] [--upstream <url>]`
 
 Clone an existing vendor setup and automatically configure all remotes.
 
@@ -172,12 +180,16 @@ Clone an existing vendor setup and automatically configure all remotes.
 
 **What it does:**
 - Clones the private mirror repository
-- **Reads venfork-config branch** for public fork and upstream URLs (if available)
-- Falls back to auto-detection:
+- **Reads venfork-config branch** for layout (`mode`) and URLs (if available)
+- Falls back to auto-detection when the config branch is absent:
   - Public fork (by stripping `-private` suffix)
   - Upstream repository (from public fork's parent)
-- Configures all three remotes (origin, public, upstream)
+- Configures the appropriate remotes (origin/upstream — plus public in standard mode)
 - Disables push to upstream (read-only)
+
+**Options** (only meaningful for **legacy mirrors** without a `venfork-config` branch — when config is present it's authoritative and the flags will error on conflict):
+- `--no-public` - Declare a no-public layout (origin + upstream only). Use when the original setup was created with `venfork setup --no-public` but the config branch is missing.
+- `--upstream <url>` - Provide the upstream URL explicitly. Useful with `--no-public` (no public fork to derive it from) or to skip the auto-detect prompt.
 
 **Use this when:**
 - A teammate has already run `venfork setup`

--- a/src/clone-args.ts
+++ b/src/clone-args.ts
@@ -1,0 +1,60 @@
+export type ParsedCloneArgs = {
+  vendorRepoUrl?: string;
+  noPublic: boolean;
+  upstreamUrl?: string;
+};
+
+function consumeValue(
+  flag: string,
+  args: string[],
+  i: number
+): { value: string; consumed: number } {
+  const equalsForm = `${flag}=`;
+  const a = args[i];
+  if (a === flag) {
+    const v = args[i + 1];
+    if (!v || v.startsWith('--')) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 1 };
+  }
+  if (a.startsWith(equalsForm)) {
+    const v = a.slice(equalsForm.length);
+    if (!v) throw new Error(`${flag} requires a value`);
+    return { value: v, consumed: 0 };
+  }
+  throw new Error(`internal: consumeValue called for non-matching arg ${a}`);
+}
+
+/**
+ * Parse `venfork clone ...` argv after the `clone` token.
+ *
+ * `--no-public` and `--upstream` are escape hatches for **legacy mirrors**
+ * that pre-date the `venfork-config` branch. When the config branch is
+ * present, the layout is read from there and these flags are unnecessary
+ * (and will conflict with the recorded `mode` if set inconsistently).
+ */
+export function parseCloneCliArgs(args: string[]): ParsedCloneArgs {
+  const positional: string[] = [];
+  let noPublic = false;
+  let upstreamUrl: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--no-public') {
+      noPublic = true;
+      continue;
+    }
+    if (a === '--upstream' || a.startsWith('--upstream=')) {
+      const { value, consumed } = consumeValue('--upstream', args, i);
+      upstreamUrl = value;
+      i += consumed;
+      continue;
+    }
+    positional.push(a);
+  }
+
+  return {
+    vendorRepoUrl: positional[0],
+    noPublic,
+    upstreamUrl: upstreamUrl?.trim() || undefined,
+  };
+}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -260,6 +260,7 @@ async function applyScheduledWorkflowCommit(
   cron: string,
   enabledWorkflows: string[],
   disabledWorkflows: string[],
+  mode: 'standard' | 'no-public',
   cwd?: string
 ): Promise<void> {
   const repoDir = cwd ?? process.cwd();
@@ -278,7 +279,7 @@ async function applyScheduledWorkflowCommit(
     });
     await writeFile(
       path.join(tempDir, SYNC_WORKFLOW_PATH),
-      generateSyncWorkflow(cron)
+      generateSyncWorkflow(cron, mode)
     );
     await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
 
@@ -505,7 +506,7 @@ async function buildPublicStageHeadWithoutWorkflowCommit(
 
 async function ensureVenforkRemotes(
   cwd: string,
-  publicUrl: string,
+  publicUrl: string | undefined,
   upstreamUrl: string
 ): Promise<void> {
   const setOrAdd = async (name: string, fetchUrl: string) => {
@@ -520,7 +521,9 @@ async function ensureVenforkRemotes(
     }
   };
 
-  await setOrAdd('public', publicUrl);
+  if (publicUrl) {
+    await setOrAdd('public', publicUrl);
+  }
   await setOrAdd('upstream', upstreamUrl);
   await $({ cwd })`git remote set-url --push upstream DISABLE`;
 }
@@ -529,13 +532,21 @@ async function ensureVenforkRemotes(
  * Setup command: Create private mirror and public fork
  *
  * @param publicForkRepoName - Optional GitHub repo name for the public fork under `owner` (see `gh repo fork --fork-name`). Defaults to the upstream repo basename. Use when the fork must differ (e.g. same org as upstream).
+ * @param options.noPublic - Skip the public-fork hop entirely. Only `origin` (private mirror) and `upstream` are configured; `stage` later pushes branches directly to `upstream`. Mutually exclusive with `publicForkRepoName`.
  */
 export async function setupCommand(
   upstreamUrl?: string,
   privateMirrorName?: string,
   organization?: string,
-  publicForkRepoName?: string
+  publicForkRepoName?: string,
+  options: { noPublic?: boolean } = {}
 ): Promise<void> {
+  const noPublic = options.noPublic === true;
+  if (noPublic && publicForkRepoName?.trim()) {
+    throw new Error(
+      '--no-public cannot be combined with a public fork name: --no-public skips creating a public fork.'
+    );
+  }
   p.intro('🔧 Venfork Setup');
 
   // Check GitHub CLI authentication
@@ -692,54 +703,58 @@ export async function setupCommand(
       ? `${organization}/${config.privateMirrorName}`
       : `${owner}/${config.privateMirrorName}`;
     const privateCloneUrl = `git@github.com:${owner}/${config.privateMirrorName}.git`;
-    const publicForkUrl = `git@github.com:${owner}/${publicForkName}.git`;
+    const publicForkUrl = noPublic
+      ? undefined
+      : `git@github.com:${owner}/${publicForkName}.git`;
 
-    // Step 1: Create public fork (or accept an existing fork under this owner)
-    s.start('Creating public fork of upstream repository');
-    const forkResult = organization
-      ? useForkNameFlag
-        ? await $({
-            reject: false,
-          })`gh repo fork ${upstreamRepoPath} --clone=false --org ${organization} --fork-name ${publicForkName}`
-        : await $({
-            reject: false,
-          })`gh repo fork ${upstreamRepoPath} --clone=false --org ${organization}`
-      : useForkNameFlag
-        ? await $({
-            reject: false,
-          })`gh repo fork ${upstreamRepoPath} --clone=false --fork-name ${publicForkName}`
-        : await $({
-            reject: false,
-          })`gh repo fork ${upstreamRepoPath} --clone=false`;
-
+    // Step 1: Create public fork (or accept an existing fork under this owner) — skipped in --no-public mode
     let forkPreexisted = false;
-    if (forkResult.exitCode !== 0) {
-      if (publicForkFullName === upstreamRepoPath && !useForkNameFlag) {
-        throw new Error(
-          `The upstream repo is already under ${owner}. Use --fork-name to give the public fork a different name.`
+    if (!noPublic) {
+      s.start('Creating public fork of upstream repository');
+      const forkResult = organization
+        ? useForkNameFlag
+          ? await $({
+              reject: false,
+            })`gh repo fork ${upstreamRepoPath} --clone=false --org ${organization} --fork-name ${publicForkName}`
+          : await $({
+              reject: false,
+            })`gh repo fork ${upstreamRepoPath} --clone=false --org ${organization}`
+        : useForkNameFlag
+          ? await $({
+              reject: false,
+            })`gh repo fork ${upstreamRepoPath} --clone=false --fork-name ${publicForkName}`
+          : await $({
+              reject: false,
+            })`gh repo fork ${upstreamRepoPath} --clone=false`;
+
+      if (forkResult.exitCode !== 0) {
+        if (publicForkFullName === upstreamRepoPath && !useForkNameFlag) {
+          throw new Error(
+            `The upstream repo is already under ${owner}. Use --fork-name to give the public fork a different name, or pass --no-public to skip the public fork hop entirely.`
+          );
+        }
+        const exists = await ghRepoExists(publicForkFullName);
+        if (!exists) {
+          throw new Error(
+            forkResult.stderr.trim() ||
+              forkResult.stdout.trim() ||
+              'gh repo fork failed'
+          );
+        }
+        const isExpectedFork = await ghRepoIsForkOf(
+          publicForkFullName,
+          upstreamRepoPath
         );
+        if (!isExpectedFork) {
+          throw new Error(
+            `Cannot reuse ${publicForkFullName} as public fork: it is not a fork of ${upstreamRepoPath}. Choose a different --fork-name.`
+          );
+        }
+        forkPreexisted = true;
+        s.stop('Public fork already exists');
+      } else {
+        s.stop('Public fork created');
       }
-      const exists = await ghRepoExists(publicForkFullName);
-      if (!exists) {
-        throw new Error(
-          forkResult.stderr.trim() ||
-            forkResult.stdout.trim() ||
-            'gh repo fork failed'
-        );
-      }
-      const isExpectedFork = await ghRepoIsForkOf(
-        publicForkFullName,
-        upstreamRepoPath
-      );
-      if (!isExpectedFork) {
-        throw new Error(
-          `Cannot reuse ${publicForkFullName} as public fork: it is not a fork of ${upstreamRepoPath}. Choose a different --fork-name.`
-        );
-      }
-      forkPreexisted = true;
-      s.stop('Public fork already exists');
-    } else {
-      s.stop('Public fork created');
     }
 
     // Step 2: Create private mirror (or accept an existing repo)
@@ -838,7 +853,12 @@ export async function setupCommand(
 
     // Step 8: Venfork config branch
     s.start('Creating venfork configuration');
-    await createConfigBranch(repoDir, publicForkUrl, config.upstreamUrl);
+    await createConfigBranch(
+      repoDir,
+      noPublic ? null : (publicForkUrl ?? null),
+      config.upstreamUrl,
+      noPublic ? 'no-public' : 'standard'
+    );
     s.stop('Venfork configuration created');
 
     const recovered = forkPreexisted || mirrorPreexisted;
@@ -857,7 +877,10 @@ export async function setupCommand(
     p.note(remotesText.trim(), 'Git Remote Configuration');
 
     p.note(
-      `Private Mirror: https://github.com/${privateMirrorGhPath} (for internal work)
+      noPublic
+        ? `Private Mirror: https://github.com/${privateMirrorGhPath} (for internal work)
+Upstream: ${config.upstreamUrl} (read-only; stage pushes branches here directly)`
+        : `Private Mirror: https://github.com/${privateMirrorGhPath} (for internal work)
 Public Fork: https://github.com/${publicForkFullName} (for staging to upstream)
 Upstream: ${config.upstreamUrl} (read-only)`,
       recovered ? 'Repositories (existing)' : 'Repositories Created'
@@ -887,7 +910,10 @@ Upstream: ${config.upstreamUrl} (read-only)`,
 /**
  * Clone command: Clone vendor repository and configure all remotes
  */
-export async function cloneCommand(vendorRepoUrl?: string): Promise<void> {
+export async function cloneCommand(
+  vendorRepoUrl?: string,
+  options: { noPublic?: boolean; upstreamUrl?: string } = {}
+): Promise<void> {
   p.intro('🔧 Venfork Clone');
 
   // Validate vendor repo URL provided
@@ -943,91 +969,150 @@ export async function cloneCommand(vendorRepoUrl?: string): Promise<void> {
     s.start('Fetching venfork configuration');
     const config = await fetchVenforkConfig(vendorCloneUrl);
 
-    let publicForkUrl: string;
+    let publicForkUrl: string | undefined;
     let upstreamUrl: string;
+    let noPublic: boolean;
 
     if (config) {
-      // Config found! Use the URLs from config
+      // Config branch is authoritative when present. Reject inconsistent
+      // user flags up front so the user notices the contradiction.
+      const configMode: 'standard' | 'no-public' =
+        config.mode === 'no-public' ? 'no-public' : 'standard';
+      if (options.noPublic && configMode === 'standard') {
+        throw new Error(
+          'Refusing to clone with --no-public: the venfork-config branch records mode=standard. To convert an existing setup, re-run `venfork setup` instead.'
+        );
+      }
+      if (options.upstreamUrl && options.upstreamUrl !== config.upstreamUrl) {
+        throw new Error(
+          `Refusing to override venfork-config: --upstream='${options.upstreamUrl}' but config records upstreamUrl='${config.upstreamUrl}'.`
+        );
+      }
+
+      noPublic = configMode === 'no-public';
       publicForkUrl = config.publicForkUrl;
       upstreamUrl = config.upstreamUrl;
 
-      const publicRepoPath = parseRepoPath(publicForkUrl);
       const upstreamRepoPath = parseRepoPath(upstreamUrl);
 
       s.stop('Configuration found');
       p.log.success(`✓ Using config from venfork-config branch`);
-      p.note(
-        `Public fork: ${publicRepoPath}\nUpstream: ${upstreamRepoPath}`,
-        'Configuration'
-      );
+      if (noPublic) {
+        p.note(
+          `Mode: no-public\nUpstream: ${upstreamRepoPath}`,
+          'Configuration'
+        );
+      } else {
+        const publicRepoPath = publicForkUrl
+          ? parseRepoPath(publicForkUrl)
+          : '(missing)';
+        p.note(
+          `Public fork: ${publicRepoPath}\nUpstream: ${upstreamRepoPath}`,
+          'Configuration'
+        );
+      }
     } else {
-      // No config found, fall back to auto-detection
-      s.stop('No configuration found, using auto-detection');
+      // No config branch (legacy mirror). Fall back to auto-detection,
+      // honoring `--no-public` / `--upstream` flags as the explicit override.
+      noPublic = options.noPublic === true;
+      s.stop(
+        noPublic
+          ? 'No configuration found, using --no-public layout'
+          : 'No configuration found, using auto-detection'
+      );
 
-      // Step 3a: Auto-detect public fork
-      s.start('Detecting public fork');
+      if (noPublic) {
+        // No public fork to look up; only resolve upstream.
+        publicForkUrl = undefined;
+        if (options.upstreamUrl) {
+          upstreamUrl = options.upstreamUrl;
+        } else {
+          const response = await p.text({
+            message:
+              'Upstream URL? (no venfork-config branch was found, so it cannot be auto-detected)',
+            placeholder: 'git@github.com:owner/repo.git',
+          });
+          if (p.isCancel(response) || !(response as string).trim()) {
+            p.outro('❌ Clone cancelled');
+            process.exit(1);
+          }
+          upstreamUrl = (response as string).trim();
+        }
+      } else {
+        // Step 3a: Auto-detect public fork
+        s.start('Detecting public fork');
 
-      // Try to strip -private suffix
-      let publicRepoName = vendorRepoName;
-      if (vendorRepoName.endsWith('-private')) {
-        publicRepoName = vendorRepoName.replace(/-private$/, '');
-      }
-
-      // Verify public fork exists
-      try {
-        await $`gh repo view ${owner}/${publicRepoName}`;
-        publicForkUrl = `git@github.com:${owner}/${publicRepoName}.git`;
-        s.stop(`Found public fork: ${owner}/${publicRepoName}`);
-      } catch {
-        s.stop('Public fork not found');
-
-        p.log.warn('⚠️  Could not auto-detect public fork.');
-        p.note(`Tried: ${owner}/${publicRepoName}`, 'Detection Failed');
-
-        const response = await p.text({
-          message: 'Please provide the public fork URL:',
-          placeholder: 'git@github.com:owner/repo.git',
-        });
-
-        if (p.isCancel(response)) {
-          p.outro('❌ Clone cancelled');
-          process.exit(1);
+        // Try to strip -private suffix
+        let publicRepoName = vendorRepoName;
+        if (vendorRepoName.endsWith('-private')) {
+          publicRepoName = vendorRepoName.replace(/-private$/, '');
         }
 
-        publicForkUrl = response as string;
-        publicRepoName = parseRepoName(publicForkUrl);
-      }
+        // Verify public fork exists
+        try {
+          await $`gh repo view ${owner}/${publicRepoName}`;
+          publicForkUrl = `git@github.com:${owner}/${publicRepoName}.git`;
+          s.stop(`Found public fork: ${owner}/${publicRepoName}`);
+        } catch {
+          s.stop('Public fork not found');
 
-      // Step 3b: Auto-detect upstream from public fork's parent
-      s.start('Detecting upstream repository');
+          p.log.warn('⚠️  Could not auto-detect public fork.');
+          p.note(
+            `Tried: ${owner}/${publicRepoName}\n\nTip: if this mirror has no public fork, re-run with --no-public --upstream <url>.`,
+            'Detection Failed'
+          );
 
-      try {
-        const result =
-          await $`gh repo view ${owner}/${publicRepoName} --json parent --jq '.parent.url'`;
-        upstreamUrl = result.stdout.trim();
+          const response = await p.text({
+            message: 'Please provide the public fork URL:',
+            placeholder: 'git@github.com:owner/repo.git',
+          });
 
-        if (!upstreamUrl || upstreamUrl === 'null') {
-          throw new Error('No parent found');
+          if (p.isCancel(response)) {
+            p.outro('❌ Clone cancelled');
+            process.exit(1);
+          }
+
+          publicForkUrl = response as string;
+          publicRepoName = parseRepoName(publicForkUrl);
         }
 
-        const upstreamPath = parseRepoPath(upstreamUrl);
-        s.stop(`Found upstream: ${upstreamPath}`);
-      } catch {
-        s.stop('Upstream not found');
+        // Step 3b: Auto-detect upstream from public fork's parent — or use
+        // --upstream if the user supplied it explicitly.
+        s.start('Detecting upstream repository');
 
-        p.log.warn('⚠️  Public fork has no parent repository.');
+        if (options.upstreamUrl) {
+          upstreamUrl = options.upstreamUrl;
+          s.stop(`Using --upstream: ${parseRepoPath(upstreamUrl)}`);
+        } else {
+          try {
+            const result =
+              await $`gh repo view ${owner}/${publicRepoName} --json parent --jq '.parent.url'`;
+            upstreamUrl = result.stdout.trim();
 
-        const response = await p.text({
-          message: 'Please provide the upstream URL:',
-          placeholder: 'git@github.com:original/repo.git',
-        });
+            if (!upstreamUrl || upstreamUrl === 'null') {
+              throw new Error('No parent found');
+            }
 
-        if (p.isCancel(response)) {
-          p.outro('❌ Clone cancelled');
-          process.exit(1);
+            const upstreamPath = parseRepoPath(upstreamUrl);
+            s.stop(`Found upstream: ${upstreamPath}`);
+          } catch {
+            s.stop('Upstream not found');
+
+            p.log.warn('⚠️  Public fork has no parent repository.');
+
+            const response = await p.text({
+              message: 'Please provide the upstream URL:',
+              placeholder: 'git@github.com:original/repo.git',
+            });
+
+            if (p.isCancel(response)) {
+              p.outro('❌ Clone cancelled');
+              process.exit(1);
+            }
+
+            upstreamUrl = response as string;
+          }
         }
-
-        upstreamUrl = response as string;
       }
     }
 
@@ -1036,8 +1121,12 @@ export async function cloneCommand(vendorRepoUrl?: string): Promise<void> {
 
     // origin is already configured from clone
 
-    // Add public fork remote
-    await $({ cwd: vendorRepoName })`git remote add public ${publicForkUrl}`;
+    // Add public fork remote (skipped in no-public mode)
+    if (!noPublic && publicForkUrl) {
+      await $({
+        cwd: vendorRepoName,
+      })`git remote add public ${publicForkUrl}`;
+    }
 
     // Add upstream remote (with push disabled)
     await $({ cwd: vendorRepoName })`git remote add upstream ${upstreamUrl}`;
@@ -1195,17 +1284,21 @@ export async function syncCommand(
       }
     }
 
+    const config = await readVenforkConfigFromRepo(repoDir);
+    const noPublic = config?.mode === 'no-public';
+
     // Step 1: Fetch from upstream
     s.start('Fetching from upstream');
     await $(cwdOpt)`git fetch upstream`;
     await $(cwdOpt)`git fetch origin`;
-    await $(cwdOpt)`git fetch public`;
+    if (!noPublic) {
+      await $(cwdOpt)`git fetch public`;
+    }
     s.stop('Fetched from all remotes');
 
     // Step 2: Detect default branch if not specified
     const defaultBranch =
       targetBranch || (await getDefaultBranch('upstream', options?.cwd));
-    const config = await readVenforkConfigFromRepo(repoDir);
     const scheduleConfig = config?.schedule;
     const enabledWorkflows = config?.enabledWorkflows ?? [];
     const disabledWorkflows = config?.disabledWorkflows ?? [];
@@ -1237,7 +1330,7 @@ export async function syncCommand(
     };
 
     const originDivergence = await checkDivergence('origin');
-    const publicDivergence = await checkDivergence('public');
+    const publicDivergence = noPublic ? 0 : await checkDivergence('public');
 
     s.stop('Checked for divergence');
 
@@ -1273,17 +1366,23 @@ To force sync anyway: git push origin upstream/${defaultBranch}:refs/heads/${def
       process.exit(1);
     }
 
-    // Step 5: Push upstream default branch to origin and public
-    s.start(`Syncing ${defaultBranch} to origin and public`);
+    // Step 5: Push upstream default branch to origin (and public, in standard mode)
+    s.start(
+      noPublic
+        ? `Syncing ${defaultBranch} to origin`
+        : `Syncing ${defaultBranch} to origin and public`
+    );
 
     await $(
       cwdOpt
     )`git push origin upstream/${defaultBranch}:refs/heads/${defaultBranch} --force-with-lease`;
-    await $(
-      cwdOpt
-    )`git push public upstream/${defaultBranch}:refs/heads/${defaultBranch} --force-with-lease`;
+    if (!noPublic) {
+      await $(
+        cwdOpt
+      )`git push public upstream/${defaultBranch}:refs/heads/${defaultBranch} --force-with-lease`;
+    }
 
-    s.stop('Synced to all remotes');
+    s.stop(noPublic ? 'Synced to origin' : 'Synced to all remotes');
 
     // Step 6: Enforce mirror "+1 commit" model for scheduled sync workflow.
     // Scheduling config lives on `venfork-config`; when enabled we re-stamp
@@ -1295,6 +1394,7 @@ To force sync anyway: git push origin upstream/${defaultBranch}:refs/heads/${def
         scheduleConfig.cron,
         enabledWorkflows,
         disabledWorkflows,
+        noPublic ? 'no-public' : 'standard',
         options?.cwd
       );
       s.stop('Scheduled workflow commit normalized');
@@ -1302,7 +1402,9 @@ To force sync anyway: git push origin upstream/${defaultBranch}:refs/heads/${def
 
     if (!quiet) {
       p.outro(
-        `✨ Sync complete! origin/${defaultBranch} and public/${defaultBranch} are now up to date with upstream/${defaultBranch}`
+        noPublic
+          ? `✨ Sync complete! origin/${defaultBranch} is now up to date with upstream/${defaultBranch}`
+          : `✨ Sync complete! origin/${defaultBranch} and public/${defaultBranch} are now up to date with upstream/${defaultBranch}`
       );
     }
   } catch (error) {
@@ -1343,16 +1445,19 @@ export async function scheduleCommand(
       }
 
       s.start('Updating schedule in venfork-config');
-      await updateVenforkConfig(repoDir, {
+      const updatedConfig = await updateVenforkConfig(repoDir, {
         schedule: { enabled: true, cron },
       });
       s.stop('Schedule configuration updated');
+
+      const scheduleMode: 'standard' | 'no-public' =
+        updatedConfig.mode === 'no-public' ? 'no-public' : 'standard';
 
       await $`git fetch origin`;
       s.start('Updating workflow on default branch');
       await updateWorkflowOnOriginDefault(
         defaultBranch,
-        generateSyncWorkflow(cron),
+        generateSyncWorkflow(cron, scheduleMode),
         repoDir
       );
       s.stop('Workflow updated');
@@ -1519,17 +1624,27 @@ export async function workflowsCommand(
  * any user confirmation so the caller can show a preview, and reused for the
  * actual push (`executeStagingPush`) and any follow-on work (e.g. opening an
  * upstream PR in `shipCommand`).
+ *
+ * `pushRemote` is the remote we push the staged branch to: `'public'` in the
+ * standard 3-remote layout, `'upstream'` in `--no-public` mode (where the
+ * branch lands directly on upstream as a same-repo PR head).
  */
 export interface StagingPlan {
   branch: string;
-  publicUrl: string;
-  publicRepoPath: string;
+  /** URL of the remote we push the staged branch to (`public` or `upstream`). */
+  pushUrl: string;
+  /** `owner/name` of the remote we push to. */
+  pushRepoPath: string;
+  /** Owner segment of `pushRepoPath` — used as the cross-repo head prefix when the PR head is in a different repo than the base. */
+  pushOwner: string;
+  /** `'public'` or `'upstream'` — which git remote name to push to. */
+  pushRemote: 'public' | 'upstream';
   upstreamUrl: string;
   upstreamRepoPath: string;
   upstreamDefaultBranch: string;
   scheduleEnabled: boolean;
-  /** owner of the public fork — first half of `publicRepoPath`. */
-  publicOwner: string;
+  /** True when the head and base of the upstream PR live in the same repo (no-public mode). */
+  noPublic: boolean;
 }
 
 /**
@@ -1546,16 +1661,8 @@ async function planStaging(branch: string, cwd: string): Promise<StagingPlan> {
     throw new BranchNotFoundError(branch);
   }
 
-  const publicUrlResult = await $({
-    cwd,
-    reject: false,
-  })`git remote get-url public`;
-  if (publicUrlResult.exitCode !== 0) {
-    throw new RemoteNotFoundError('public');
-  }
-  const publicUrl = publicUrlResult.stdout.trim();
-  const publicRepoPath = parseRepoPath(publicUrl);
-  const publicOwner = publicRepoPath.split('/')[0] ?? '';
+  const config = await readVenforkConfigFromRepo(cwd);
+  const noPublic = config?.mode === 'no-public';
 
   const upstreamUrlResult = await $({
     cwd,
@@ -1567,18 +1674,41 @@ async function planStaging(branch: string, cwd: string): Promise<StagingPlan> {
   const upstreamUrl = upstreamUrlResult.stdout.trim();
   const upstreamRepoPath = parseRepoPath(upstreamUrl);
 
+  let pushUrl: string;
+  let pushRepoPath: string;
+  let pushRemote: 'public' | 'upstream';
+  if (noPublic) {
+    pushUrl = upstreamUrl;
+    pushRepoPath = upstreamRepoPath;
+    pushRemote = 'upstream';
+  } else {
+    const publicUrlResult = await $({
+      cwd,
+      reject: false,
+    })`git remote get-url public`;
+    if (publicUrlResult.exitCode !== 0) {
+      throw new RemoteNotFoundError('public');
+    }
+    pushUrl = publicUrlResult.stdout.trim();
+    pushRepoPath = parseRepoPath(pushUrl);
+    pushRemote = 'public';
+  }
+  const pushOwner = pushRepoPath.split('/')[0] ?? '';
+
   const upstreamDefaultBranch = await getDefaultBranch('upstream');
   const scheduleEnabled = await isScheduleEnabled(cwd);
 
   return {
     branch,
-    publicUrl,
-    publicRepoPath,
+    pushUrl,
+    pushRepoPath,
+    pushOwner,
+    pushRemote,
     upstreamUrl,
     upstreamRepoPath,
     upstreamDefaultBranch,
     scheduleEnabled,
-    publicOwner,
+    noPublic,
   };
 }
 
@@ -1594,10 +1724,12 @@ async function executeStagingPush(
   cwd: string,
   s: ReturnType<typeof p.spinner>
 ): Promise<string> {
+  const remote = plan.pushRemote;
+  const target = plan.noPublic ? 'upstream' : 'public fork';
   if (plan.scheduleEnabled) {
     await $({ cwd })`git fetch upstream`;
     await $({ cwd })`git fetch origin`;
-    s.start('Preparing sanitized branch for public staging');
+    s.start(`Preparing sanitized branch for ${target} staging`);
     const stageHead = await buildPublicStageHeadWithoutWorkflowCommit(
       plan.branch,
       plan.upstreamDefaultBranch,
@@ -1605,22 +1737,22 @@ async function executeStagingPush(
     );
     s.stop('Prepared sanitized branch');
 
-    s.start('Pushing sanitized branch to public fork');
-    if (await remoteBranchExists('public', plan.branch)) {
+    s.start(`Pushing sanitized branch to ${target}`);
+    if (await remoteBranchExists(remote, plan.branch)) {
       await $({
         cwd,
-      })`git push public ${stageHead}:refs/heads/${plan.branch} --force-with-lease=refs/heads/${plan.branch}`;
+      })`git push ${remote} ${stageHead}:refs/heads/${plan.branch} --force-with-lease=refs/heads/${plan.branch}`;
     } else {
       await $({
         cwd,
-      })`git push public ${stageHead}:refs/heads/${plan.branch}`;
+      })`git push ${remote} ${stageHead}:refs/heads/${plan.branch}`;
     }
     s.stop('Push successful');
     return stageHead;
   }
 
-  s.start('Pushing to public fork');
-  await $({ cwd })`git push public ${plan.branch}`;
+  s.start(`Pushing to ${target}`);
+  await $({ cwd })`git push ${remote} ${plan.branch}`;
   s.stop('Push successful');
   const headResult = await $({
     cwd,
@@ -1869,7 +2001,10 @@ async function buildUpstreamPrPayload(
  */
 async function createUpstreamPr(args: {
   upstreamRepoPath: string;
-  publicOwner: string;
+  /** Owner where the head branch lives. Same as upstream owner in no-public mode. */
+  headOwner: string;
+  /** True when head and base live in the same repo (no-public mode) — gh wants a bare branch name in that case, not `owner:branch`. */
+  sameRepoHead: boolean;
   branch: string;
   base: string;
   title: string;
@@ -1877,7 +2012,9 @@ async function createUpstreamPr(args: {
   draft: boolean;
   cwd: string;
 }): Promise<{ url: string; alreadyExists: boolean }> {
-  const head = `${args.publicOwner}:${args.branch}`;
+  const head = args.sameRepoHead
+    ? args.branch
+    : `${args.headOwner}:${args.branch}`;
   const result = await $({
     cwd: args.cwd,
     reject: false,
@@ -1977,14 +2114,23 @@ export async function stageCommand(
       );
     }
 
-    const detailLines = [
-      `Branch '${plan.branch}' will be pushed to your public fork.`,
-      'This makes your work visible and ready for PR to upstream.',
-      '',
-      `  From: Private vendor repo (current)`,
-      `  To:   ${plan.publicUrl}`,
-      `  PR:   ${plan.publicRepoPath} → ${plan.upstreamRepoPath}`,
-    ];
+    const detailLines = plan.noPublic
+      ? [
+          `Branch '${plan.branch}' will be pushed directly to upstream.`,
+          'This makes your work visible and ready for PR within upstream.',
+          '',
+          `  From: Private vendor repo (current)`,
+          `  To:   ${plan.pushUrl}`,
+          `  PR:   ${plan.upstreamRepoPath}@${plan.branch} → ${plan.upstreamRepoPath}`,
+        ]
+      : [
+          `Branch '${plan.branch}' will be pushed to your public fork.`,
+          'This makes your work visible and ready for PR to upstream.',
+          '',
+          `  From: Private vendor repo (current)`,
+          `  To:   ${plan.pushUrl}`,
+          `  PR:   ${plan.pushRepoPath} → ${plan.upstreamRepoPath}`,
+        ];
     if (createPr) {
       detailLines.push(
         '',
@@ -2004,9 +2150,13 @@ export async function stageCommand(
     }
 
     const shouldStage = await confirmOrAutoYes({
-      message: createPr
-        ? 'Push to public fork and open the upstream PR?'
-        : 'Push to public fork?',
+      message: plan.noPublic
+        ? createPr
+          ? 'Push to upstream and open the PR?'
+          : 'Push to upstream?'
+        : createPr
+          ? 'Push to public fork and open the upstream PR?'
+          : 'Push to public fork?',
       initialValue: false,
       allowNonInteractive: createPr,
     });
@@ -2030,7 +2180,8 @@ export async function stageCommand(
       try {
         const result = await createUpstreamPr({
           upstreamRepoPath: plan.upstreamRepoPath,
-          publicOwner: plan.publicOwner,
+          headOwner: plan.pushOwner,
+          sameRepoHead: plan.noPublic,
           branch: plan.branch,
           base: baseBranch,
           title: prTitle,
@@ -2095,8 +2246,11 @@ export async function stageCommand(
 
     // Use the resolved baseBranch (which respects --base) so the compare URL
     // points at the same base the user asked for, even if --pr wasn't set
-    // or `gh pr create` failed earlier.
-    const prUrl = `https://github.com/${plan.upstreamRepoPath}/compare/${baseBranch}...${plan.publicOwner}:${plan.branch}?expand=1`;
+    // or `gh pr create` failed earlier. In no-public mode the head and base
+    // live in the same repo, so gh's compare URL accepts a bare branch name.
+    const prUrl = plan.noPublic
+      ? `https://github.com/${plan.upstreamRepoPath}/compare/${baseBranch}...${plan.branch}?expand=1`
+      : `https://github.com/${plan.upstreamRepoPath}/compare/${baseBranch}...${plan.pushOwner}:${plan.branch}?expand=1`;
 
     if (createPr && upstreamPrUrl) {
       const lines = [`Upstream PR: ${upstreamPrUrl}`];
@@ -2106,7 +2260,9 @@ export async function stageCommand(
       p.note(lines.join('\n'), 'Next Steps');
     } else {
       p.note(
-        `Your branch is now on the public fork!\n\nCreate a pull request to upstream:\n  ${prUrl}\n\n(Tip: re-run with --pr to open it automatically.)`,
+        plan.noPublic
+          ? `Your branch is now on upstream!\n\nCreate a pull request:\n  ${prUrl}\n\n(Tip: re-run with --pr to open it automatically.)`
+          : `Your branch is now on the public fork!\n\nCreate a pull request to upstream:\n  ${prUrl}\n\n(Tip: re-run with --pr to open it automatically.)`,
         'Next Steps'
       );
     }
@@ -2657,8 +2813,21 @@ export async function statusCommand(): Promise<void> {
   const hasPublic = await hasRemote('public');
   const hasUpstream = await hasRemote('upstream');
 
+  // Mode is read from venfork-config; absent ⇒ standard. Use a best-effort
+  // read so a missing/unreadable config doesn't break `status`.
+  let mode: 'standard' | 'no-public' = 'standard';
+  try {
+    const cfgForMode = await readVenforkConfigFromRepo(process.cwd());
+    if (cfgForMode?.mode === 'no-public') {
+      mode = 'no-public';
+    }
+  } catch {
+    // Fall through to 'standard'.
+  }
+  const noPublic = mode === 'no-public';
+
   // Check if setup is complete
-  const isSetupComplete = hasOrigin && hasPublic && hasUpstream;
+  const isSetupComplete = hasOrigin && hasUpstream && (noPublic || hasPublic);
 
   // Display git remotes
   if (Object.keys(remotes).length > 0) {
@@ -2678,12 +2847,15 @@ export async function statusCommand(): Promise<void> {
   // Display status
   const statusLines = [
     `Current branch: ${currentBranch || '(detached HEAD)'}`,
+    `Mode: ${mode}`,
     '',
     'Setup status:',
     `  ${hasOrigin ? '✓' : '✗'} origin (private mirror)`,
-    `  ${hasPublic ? '✓' : '✗'} public (public fork)`,
-    `  ${hasUpstream ? '✓' : '✗'} upstream (original repo)`,
   ];
+  if (!noPublic) {
+    statusLines.push(`  ${hasPublic ? '✓' : '✗'} public (public fork)`);
+  }
+  statusLines.push(`  ${hasUpstream ? '✓' : '✗'} upstream (original repo)`);
 
   p.note(statusLines.join('\n'), 'Repository Status');
 
@@ -2760,7 +2932,7 @@ export async function statusCommand(): Promise<void> {
   } else {
     const missingRemotes = [];
     if (!hasOrigin) missingRemotes.push('origin');
-    if (!hasPublic) missingRemotes.push('public');
+    if (!noPublic && !hasPublic) missingRemotes.push('public');
     if (!hasUpstream) missingRemotes.push('upstream');
 
     p.note(
@@ -2778,7 +2950,7 @@ export function showHelp(): void {
   p.intro('🔧 Venfork - Private Repository Mirrors for Vendor Development');
 
   p.note(
-    `venfork setup <upstream> [name] [--org <org>] [--fork-name <repo>]
+    `venfork setup <upstream> [name] [--org <org>] [--fork-name <repo>] [--no-public]
   Create private mirror + public fork for vendor workflow
   <upstream>: GitHub HTTPS/SSH URL, or shorthand owner/repo (e.g. facebook/react)
 
@@ -2786,20 +2958,29 @@ export function showHelp(): void {
   • --org <name>       Create repos under organization instead of user account
   • --fork-name <name> Public fork repo name under owner (gh repo fork --fork-name).
                        Use when upstream is already owner/repo so the fork needs a different name.
+  • --no-public        Skip the public fork hop entirely. Only origin + upstream are
+                       configured; \`venfork stage\` later pushes branches directly to upstream.
+                       Use when you own the upstream repo (no need to round-trip through a fork).
+                       Mutually exclusive with --fork-name.
 
   Creates:
   • Private mirror (yourname/project-private) - internal work
-  • Public fork (yourname/project) - staging for upstream
-  • Configures remotes: origin, public, upstream
+  • Public fork (yourname/project) - staging for upstream (omitted with --no-public)
+  • Configures remotes: origin, public, upstream (public omitted with --no-public)
 
-venfork clone <vendor-repo>
+venfork clone <vendor-repo> [--no-public] [--upstream <url>]
   Clone an existing vendor setup and configure remotes automatically
   <vendor-repo>: URL or owner/repo for the private mirror
 
-  Auto-detects:
+  Reads layout (mode + URLs) from the venfork-config branch when present.
+  Falls back to auto-detection when the branch is absent (legacy mirrors):
   • Public fork (strips -private suffix)
   • Upstream repository (from public fork's parent)
-  • Configures all three remotes (origin, public, upstream)
+  • Configures three remotes (origin, public, upstream)
+
+  Options (only meaningful when venfork-config is absent):
+  • --no-public        Declare a no-public layout (origin + upstream only)
+  • --upstream <url>   Provide the upstream URL explicitly (skips auto-detect/prompt)
 
 venfork status
   Show current repository setup and configuration

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -523,6 +523,16 @@ async function ensureVenforkRemotes(
 
   if (publicUrl) {
     await setOrAdd('public', publicUrl);
+  } else {
+    // No-public mode: remove a stale `public` remote left over from a prior
+    // standard-mode setup so the local layout matches the recorded config.
+    const existing = await $({
+      cwd,
+      reject: false,
+    })`git remote get-url public`;
+    if (existing.exitCode === 0) {
+      await $({ cwd })`git remote remove public`;
+    }
   }
   await setOrAdd('upstream', upstreamUrl);
   await $({ cwd })`git remote set-url --push upstream DISABLE`;
@@ -1724,8 +1734,14 @@ async function executeStagingPush(
   cwd: string,
   s: ReturnType<typeof p.spinner>
 ): Promise<string> {
-  const remote = plan.pushRemote;
+  // In no-public mode the `upstream` remote has its push URL set to DISABLE
+  // (so a stray `git push upstream main` from CLI/IDE can't ship the private
+  // mirror's history to upstream's default branch). Stage opts in explicitly
+  // by pushing to the URL, which bypasses the disabled push URL while
+  // leaving the safeguard in place for non-stage workflows.
+  const pushDest = plan.noPublic ? plan.pushUrl : plan.pushRemote;
   const target = plan.noPublic ? 'upstream' : 'public fork';
+
   if (plan.scheduleEnabled) {
     await $({ cwd })`git fetch upstream`;
     await $({ cwd })`git fetch origin`;
@@ -1738,21 +1754,43 @@ async function executeStagingPush(
     s.stop('Prepared sanitized branch');
 
     s.start(`Pushing sanitized branch to ${target}`);
-    if (await remoteBranchExists(remote, plan.branch)) {
-      await $({
+    if (plan.noPublic) {
+      // URL push: `--force-with-lease=<ref>` (no expect) relies on a
+      // remote-tracking ref that doesn't exist for URL pushes, so resolve
+      // the remote tip explicitly via ls-remote and pass it as the lease.
+      const ls = await $({
         cwd,
-      })`git push ${remote} ${stageHead}:refs/heads/${plan.branch} --force-with-lease=refs/heads/${plan.branch}`;
+        reject: false,
+      })`git ls-remote --exit-code ${pushDest} refs/heads/${plan.branch}`;
+      if (ls.exitCode === 0) {
+        const expectedSha = ls.stdout.trim().split(/\s+/)[0] ?? '';
+        await $({
+          cwd,
+        })`git push ${pushDest} ${stageHead}:refs/heads/${plan.branch} --force-with-lease=refs/heads/${plan.branch}:${expectedSha}`;
+      } else {
+        await $({
+          cwd,
+        })`git push ${pushDest} ${stageHead}:refs/heads/${plan.branch}`;
+      }
     } else {
-      await $({
-        cwd,
-      })`git push ${remote} ${stageHead}:refs/heads/${plan.branch}`;
+      // Standard mode: remote name with the implicit-lease form (lease
+      // value comes from refs/remotes/public/<branch>).
+      if (await remoteBranchExists(plan.pushRemote, plan.branch)) {
+        await $({
+          cwd,
+        })`git push ${plan.pushRemote} ${stageHead}:refs/heads/${plan.branch} --force-with-lease=refs/heads/${plan.branch}`;
+      } else {
+        await $({
+          cwd,
+        })`git push ${plan.pushRemote} ${stageHead}:refs/heads/${plan.branch}`;
+      }
     }
     s.stop('Push successful');
     return stageHead;
   }
 
   s.start(`Pushing to ${target}`);
-  await $({ cwd })`git push ${remote} ${plan.branch}`;
+  await $({ cwd })`git push ${pushDest} ${plan.branch}`;
   s.stop('Push successful');
   const headResult = await $({
     cwd,

--- a/src/config.ts
+++ b/src/config.ts
@@ -63,7 +63,15 @@ export interface PulledIssue {
  */
 export interface VenforkConfig {
   version: string;
-  publicForkUrl: string;
+  /**
+   * Repo layout. `'standard'` (default when absent) is the three-remote
+   * setup with a public fork hop. `'no-public'` collapses the layout to
+   * `origin` (private mirror) + `upstream` only — used when the upstream
+   * repo lives in the user's own org so the fork hop is unnecessary.
+   */
+  mode?: 'standard' | 'no-public';
+  /** Required in `'standard'` mode; omitted in `'no-public'` mode. */
+  publicForkUrl?: string;
   upstreamUrl: string;
   schedule?: {
     cron: string;
@@ -118,17 +126,30 @@ export type VenforkConfigPatch = Omit<
 
 /**
  * Creates and pushes a venfork config branch to the origin remote.
+ *
+ * Pass `publicForkUrl: null` (with `mode: 'no-public'`) when the layout
+ * skips the public fork hop.
  */
 export async function createConfigBranch(
   repoDir: string,
-  publicForkUrl: string,
-  upstreamUrl: string
+  publicForkUrl: string | null,
+  upstreamUrl: string,
+  mode: 'standard' | 'no-public' = 'standard'
 ): Promise<void> {
   const config: VenforkConfig = {
     version: '1',
-    publicForkUrl,
     upstreamUrl,
   };
+  if (mode === 'no-public') {
+    config.mode = 'no-public';
+  } else {
+    if (!publicForkUrl) {
+      throw new Error(
+        'createConfigBranch: publicForkUrl is required for standard mode'
+      );
+    }
+    config.publicForkUrl = publicForkUrl;
+  }
 
   await writeConfigBranch(repoDir, config, 'Initialize venfork configuration');
 }
@@ -325,13 +346,31 @@ function normalizeBranchMap<T>(
 }
 
 function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
-  if (!config.version || !config.publicForkUrl || !config.upstreamUrl) {
+  if (!config.version || !config.upstreamUrl) {
+    return null;
+  }
+
+  const mode: 'standard' | 'no-public' =
+    config.mode === 'no-public' ? 'no-public' : 'standard';
+
+  if (mode === 'standard' && !config.publicForkUrl) {
+    return null;
+  }
+  if (mode === 'no-public' && config.publicForkUrl) {
+    // mode/publicForkUrl must agree — reject the ambiguous combo so a
+    // hand-edit can't leave the config in a contradictory state.
     return null;
   }
 
   const normalized: VenforkConfig = {
     ...config,
   };
+  if (mode === 'no-public') {
+    normalized.mode = 'no-public';
+    delete normalized.publicForkUrl;
+  } else {
+    delete normalized.mode;
+  }
 
   if (normalized.schedule) {
     const cron = normalized.schedule.cron?.trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import * as p from '@clack/prompts';
+import { parseCloneCliArgs } from './clone-args.js';
 import {
   cloneCommand,
   issueCommand,
@@ -43,13 +44,19 @@ async function main(): Promise<void> {
         parsed.upstreamUrl,
         parsed.privateMirrorName,
         parsed.organization,
-        parsed.publicForkRepoName
+        parsed.publicForkRepoName,
+        { noPublic: parsed.noPublic }
       );
       break;
     }
-    case 'clone':
-      await cloneCommand(args[1]);
+    case 'clone': {
+      const parsed = parseCloneCliArgs(args.slice(1));
+      await cloneCommand(parsed.vendorRepoUrl, {
+        noPublic: parsed.noPublic,
+        upstreamUrl: parsed.upstreamUrl,
+      });
       break;
+    }
     case 'sync':
       await syncCommand(args[1]);
       break;

--- a/src/setup-args.ts
+++ b/src/setup-args.ts
@@ -3,6 +3,7 @@ export type ParsedSetupArgs = {
   privateMirrorName?: string;
   organization?: string;
   publicForkRepoName?: string;
+  noPublic: boolean;
 };
 
 /**
@@ -12,6 +13,7 @@ export function parseSetupCliArgs(setupArgs: string[]): ParsedSetupArgs {
   const positional: string[] = [];
   let organization: string | undefined;
   let publicForkRepoName: string | undefined;
+  let noPublic = false;
 
   for (let i = 0; i < setupArgs.length; i++) {
     const a = setupArgs[i];
@@ -41,13 +43,25 @@ export function parseSetupCliArgs(setupArgs: string[]): ParsedSetupArgs {
       publicForkRepoName = val;
       continue;
     }
+    if (a === '--no-public') {
+      noPublic = true;
+      continue;
+    }
     positional.push(a);
+  }
+
+  const trimmedForkName = publicForkRepoName?.trim() || undefined;
+  if (noPublic && trimmedForkName) {
+    throw new Error(
+      '--no-public cannot be combined with --fork-name: --no-public skips creating a public fork entirely.'
+    );
   }
 
   return {
     upstreamUrl: positional[0],
     privateMirrorName: positional[1],
     organization: organization ?? process.env.VENFORK_ORG,
-    publicForkRepoName: publicForkRepoName?.trim() || undefined,
+    publicForkRepoName: trimmedForkName,
+    noPublic,
   };
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -15,9 +15,45 @@ function escapeCronForYaml(cron: string): string {
 
 /**
  * Generates deterministic GitHub Actions workflow YAML for scheduled sync.
+ *
+ * In `'standard'` mode the workflow configures both `upstream` and `public`
+ * remotes; in `'no-public'` mode the public-remote block is omitted so the
+ * sync only mirrors upstream → origin.
  */
-export function generateSyncWorkflow(cron: string): string {
+export function generateSyncWorkflow(
+  cron: string,
+  mode: 'standard' | 'no-public' = 'standard'
+): string {
   const safeCron = escapeCronForYaml(cron);
+  const noPublic = mode === 'no-public';
+
+  const remotesScript = noPublic
+    ? `          set -euo pipefail
+          git fetch origin venfork-config
+          CONFIG_JSON="$(git show FETCH_HEAD:.venfork/config.json)"
+          UPSTREAM_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.upstreamUrl || '')" "$CONFIG_JSON")"
+          if [ -z "$UPSTREAM_URL" ]; then
+            echo "Missing upstream URL in venfork-config"
+            exit 1
+          fi
+          git remote remove upstream 2>/dev/null || true
+          git remote add upstream "$UPSTREAM_URL"
+          git remote set-url --push upstream DISABLE`
+    : `          set -euo pipefail
+          git fetch origin venfork-config
+          CONFIG_JSON="$(git show FETCH_HEAD:.venfork/config.json)"
+          UPSTREAM_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.upstreamUrl || '')" "$CONFIG_JSON")"
+          PUBLIC_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.publicForkUrl || '')" "$CONFIG_JSON")"
+          if [ -z "$UPSTREAM_URL" ] || [ -z "$PUBLIC_URL" ]; then
+            echo "Missing upstream/public URL in venfork-config"
+            exit 1
+          fi
+          git remote remove upstream 2>/dev/null || true
+          git remote remove public 2>/dev/null || true
+          git remote add upstream "$UPSTREAM_URL"
+          git remote set-url --push upstream DISABLE
+          git remote add public "$PUBLIC_URL"`;
+
   return `name: ${WORKFLOW_NAME}
 on:
   schedule:
@@ -51,20 +87,7 @@ jobs:
       - name: Configure venfork remotes
         shell: bash
         run: |
-          set -euo pipefail
-          git fetch origin venfork-config
-          CONFIG_JSON="$(git show FETCH_HEAD:.venfork/config.json)"
-          UPSTREAM_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.upstreamUrl || '')" "$CONFIG_JSON")"
-          PUBLIC_URL="$(node -e "const c = JSON.parse(process.argv[1]); process.stdout.write(c.publicForkUrl || '')" "$CONFIG_JSON")"
-          if [ -z "$UPSTREAM_URL" ] || [ -z "$PUBLIC_URL" ]; then
-            echo "Missing upstream/public URL in venfork-config"
-            exit 1
-          fi
-          git remote remove upstream 2>/dev/null || true
-          git remote remove public 2>/dev/null || true
-          git remote add upstream "$UPSTREAM_URL"
-          git remote set-url --push upstream DISABLE
-          git remote add public "$PUBLIC_URL"
+${remotesScript}
       - name: Sync from upstream
         run: venfork sync
 `;

--- a/tests/clone-args.test.ts
+++ b/tests/clone-args.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { parseCloneCliArgs } from '../src/clone-args.js';
+
+describe('parseCloneCliArgs', () => {
+  test('parses bare positional vendor URL', () => {
+    expect(parseCloneCliArgs(['git@github.com:acme/proj-private.git'])).toEqual(
+      {
+        vendorRepoUrl: 'git@github.com:acme/proj-private.git',
+        noPublic: false,
+        upstreamUrl: undefined,
+      }
+    );
+  });
+
+  test('--no-public sets the flag', () => {
+    expect(parseCloneCliArgs(['acme/proj-private', '--no-public'])).toEqual({
+      vendorRepoUrl: 'acme/proj-private',
+      noPublic: true,
+      upstreamUrl: undefined,
+    });
+  });
+
+  test('--upstream value form', () => {
+    expect(
+      parseCloneCliArgs([
+        'acme/proj-private',
+        '--no-public',
+        '--upstream',
+        'git@github.com:acme/proj.git',
+      ])
+    ).toEqual({
+      vendorRepoUrl: 'acme/proj-private',
+      noPublic: true,
+      upstreamUrl: 'git@github.com:acme/proj.git',
+    });
+  });
+
+  test('--upstream= form', () => {
+    expect(
+      parseCloneCliArgs([
+        'acme/proj-private',
+        '--upstream=git@github.com:acme/proj.git',
+      ])
+    ).toEqual({
+      vendorRepoUrl: 'acme/proj-private',
+      noPublic: false,
+      upstreamUrl: 'git@github.com:acme/proj.git',
+    });
+  });
+
+  test('throws when --upstream has no value', () => {
+    expect(() => parseCloneCliArgs(['a/b', '--upstream'])).toThrow(
+      '--upstream requires a value'
+    );
+  });
+
+  test('throws when --upstream= is empty', () => {
+    expect(() => parseCloneCliArgs(['a/b', '--upstream='])).toThrow(
+      '--upstream requires a value'
+    );
+  });
+
+  test('flag order does not matter', () => {
+    expect(
+      parseCloneCliArgs([
+        '--no-public',
+        '--upstream=git@github.com:acme/proj.git',
+        'acme/proj-private',
+      ])
+    ).toEqual({
+      vendorRepoUrl: 'acme/proj-private',
+      noPublic: true,
+      upstreamUrl: 'git@github.com:acme/proj.git',
+    });
+  });
+});

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -2844,3 +2844,261 @@ describe('issueCommand', () => {
     ).toBe(true);
   });
 });
+
+/**
+ * `--no-public` mode collapses the 3-remote layout (origin/public/upstream)
+ * to 2 remotes (origin/upstream) for users whose upstream lives in their own
+ * org. These tests cover the behaviour fan-out across setup/sync/stage/status.
+ */
+describe('no-public mode', () => {
+  /** Convenience: returns a venfork-config JSON for the given mode. */
+  const noPublicConfig = (extra: Record<string, unknown> = {}) =>
+    JSON.stringify({
+      version: '1',
+      mode: 'no-public',
+      upstreamUrl: 'git@github.com:upstream/repo.git',
+      ...extra,
+    });
+
+  describe('setupCommand --no-public', () => {
+    test('skips gh repo fork', async () => {
+      try {
+        await setupCommand(
+          'git@github.com:test/repo.git',
+          'test-vendor',
+          undefined,
+          undefined,
+          { noPublic: true }
+        );
+      } catch {
+        // Expected in mocked env
+      }
+
+      const forkCalls = execaCalls.filter((c) => c.includes('gh repo fork'));
+      expect(forkCalls.length).toBe(0);
+    });
+
+    test('does not add `public` remote', async () => {
+      try {
+        await setupCommand(
+          'git@github.com:test/repo.git',
+          'test-vendor',
+          undefined,
+          undefined,
+          { noPublic: true }
+        );
+      } catch {
+        // Expected
+      }
+
+      const remoteAddPublic = execaCalls.filter(
+        (c) =>
+          c.includes('git remote add public') ||
+          c.includes('git remote set-url public')
+      );
+      expect(remoteAddPublic.length).toBe(0);
+    });
+
+    test('still adds upstream remote with push DISABLEd', async () => {
+      try {
+        await setupCommand(
+          'git@github.com:test/repo.git',
+          'test-vendor',
+          undefined,
+          undefined,
+          { noPublic: true }
+        );
+      } catch {
+        // Expected
+      }
+
+      expect(
+        execaCalls.some((c) => c.includes('git remote set-url --push upstream'))
+      ).toBe(true);
+    });
+
+    test('writes venfork-config with mode=no-public and no publicForkUrl', async () => {
+      try {
+        await setupCommand(
+          'git@github.com:test/repo.git',
+          'test-vendor',
+          undefined,
+          undefined,
+          { noPublic: true }
+        );
+      } catch {
+        // Expected
+      }
+
+      const configWrite = writeFileCalls.find((w) =>
+        w.path.endsWith('.venfork/config.json')
+      );
+      expect(configWrite).toBeDefined();
+      const parsed = JSON.parse(configWrite?.content ?? '{}');
+      expect(parsed.mode).toBe('no-public');
+      expect(parsed.publicForkUrl).toBeUndefined();
+      expect(parsed.upstreamUrl).toBe('git@github.com:test/repo.git');
+    });
+
+    test('throws when combined with a public fork name', async () => {
+      await expect(
+        setupCommand(
+          'git@github.com:test/repo.git',
+          'test-vendor',
+          undefined,
+          'forked-name',
+          { noPublic: true }
+        )
+      ).rejects.toThrow(/no-public.*public fork name/i);
+    });
+  });
+
+  describe('syncCommand in no-public mode', () => {
+    test('skips fetch public', async () => {
+      mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+        exitCode: 0,
+        stdout: noPublicConfig(),
+        stderr: '',
+      });
+
+      try {
+        await syncCommand('main');
+      } catch {
+        // Expected
+      }
+
+      expect(execaCalls.some((c) => c.includes('git fetch upstream'))).toBe(
+        true
+      );
+      expect(execaCalls.some((c) => c.includes('git fetch origin'))).toBe(true);
+      expect(execaCalls.some((c) => c.includes('git fetch public'))).toBe(
+        false
+      );
+    });
+
+    test('does not push to public', async () => {
+      mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+        exitCode: 0,
+        stdout: noPublicConfig(),
+        stderr: '',
+      });
+
+      try {
+        await syncCommand('main');
+      } catch {
+        // Expected
+      }
+
+      const pushCalls = execaCalls.filter((c) => c.includes('git push'));
+      expect(pushCalls.some((c) => c.includes('git push public'))).toBe(false);
+      expect(pushCalls.some((c) => c.includes('git push origin'))).toBe(true);
+    });
+  });
+
+  describe('stageCommand in no-public mode', () => {
+    test('pushes to upstream remote, not public', async () => {
+      mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+        exitCode: 0,
+        stdout: noPublicConfig(),
+        stderr: '',
+      });
+      // upstream remote URL lookup (planStaging path)
+      mockResponses.set('git remote get-url upstream', {
+        exitCode: 0,
+        stdout: 'git@github.com:upstream/repo.git',
+        stderr: '',
+      });
+
+      try {
+        await stageCommand('feature-branch');
+      } catch {
+        // Expected
+      }
+
+      // Should never query `git remote get-url public` in no-public mode.
+      expect(
+        execaCalls.some((c) => c.includes('git remote get-url public'))
+      ).toBe(false);
+
+      const pushCalls = execaCalls.filter((c) => c.includes('git push'));
+      expect(pushCalls.some((c) => c.includes('git push upstream'))).toBe(true);
+      expect(pushCalls.some((c) => c.includes('git push public'))).toBe(false);
+    });
+  });
+
+  describe('cloneCommand --no-public for legacy mirrors', () => {
+    test('skips public-fork detection when --no-public is set and no config exists', async () => {
+      // No mock for `git show FETCH_HEAD:.venfork/config.json` and the
+      // default `gh repo clone` mock returns empty stdout — fetchVenforkConfig
+      // returns null. The flag becomes the source of truth.
+      try {
+        await cloneCommand('git@github.com:acme/legacy-private.git', {
+          noPublic: true,
+          upstreamUrl: 'git@github.com:acme/legacy.git',
+        });
+      } catch {
+        // Expected
+      }
+
+      // Should NOT call `gh repo view <owner>/legacy` (public-fork lookup).
+      expect(
+        execaCalls.some(
+          (c) =>
+            c.includes('gh repo view') &&
+            c.includes('acme/legacy') &&
+            !c.includes('--json')
+        )
+      ).toBe(false);
+      // Should NOT call the parent-lookup either.
+      expect(
+        execaCalls.some(
+          (c) => c.includes('gh repo view') && c.includes('--json parent')
+        )
+      ).toBe(false);
+    });
+
+    test('does not add a public remote in legacy --no-public mode', async () => {
+      try {
+        await cloneCommand('git@github.com:acme/legacy-private.git', {
+          noPublic: true,
+          upstreamUrl: 'git@github.com:acme/legacy.git',
+        });
+      } catch {
+        // Expected
+      }
+
+      const remoteAddPublic = execaCalls.filter((c) =>
+        c.includes('git remote add public')
+      );
+      expect(remoteAddPublic.length).toBe(0);
+
+      // upstream remote IS added.
+      expect(
+        execaCalls.some((c) => c.includes('git remote add upstream'))
+      ).toBe(true);
+    });
+  });
+
+  describe('statusCommand in no-public mode', () => {
+    test('completes without error when public remote is absent', async () => {
+      mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+        exitCode: 0,
+        stdout: noPublicConfig(),
+        stderr: '',
+      });
+      // hasRemote uses `git remote get-url <name>` — make `public` look missing
+      // while origin/upstream remain present (default success mock).
+      mockResponses.set('git remote get-url public', {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'No such remote',
+      });
+
+      // The sentinel: in standard mode, missing `public` would produce an
+      // "incomplete" path that still does not throw, but importantly
+      // statusCommand should not raise on the noPublic branch. A clean
+      // completion (no thrown error) is the assertion.
+      await expect(statusCommand()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -2951,6 +2951,34 @@ describe('no-public mode', () => {
         )
       ).rejects.toThrow(/no-public.*public fork name/i);
     });
+
+    test('removes a stale `public` remote when re-running in no-public mode', async () => {
+      // Simulate a repo that previously had a `public` remote configured —
+      // `git remote get-url public` succeeds with a URL. Re-running setup
+      // with --no-public should explicitly remove it so the local layout
+      // matches the recorded config.
+      mockResponses.set('git remote get-url public', {
+        exitCode: 0,
+        stdout: 'git@github.com:test/repo.git',
+        stderr: '',
+      });
+
+      try {
+        await setupCommand(
+          'git@github.com:test/repo.git',
+          'test-vendor',
+          undefined,
+          undefined,
+          { noPublic: true }
+        );
+      } catch {
+        // Expected in mocked env
+      }
+
+      expect(
+        execaCalls.some((c) => c.includes('git remote remove public'))
+      ).toBe(true);
+    });
   });
 
   describe('syncCommand in no-public mode', () => {
@@ -2996,7 +3024,7 @@ describe('no-public mode', () => {
   });
 
   describe('stageCommand in no-public mode', () => {
-    test('pushes to upstream remote, not public', async () => {
+    test('pushes by upstream URL (not by remote name) so DISABLE push URL is bypassed', async () => {
       mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
         exitCode: 0,
         stdout: noPublicConfig(),
@@ -3021,8 +3049,54 @@ describe('no-public mode', () => {
       ).toBe(false);
 
       const pushCalls = execaCalls.filter((c) => c.includes('git push'));
-      expect(pushCalls.some((c) => c.includes('git push upstream'))).toBe(true);
+      // Push goes to the upstream URL (so the DISABLEd push URL on the
+      // `upstream` remote is bypassed). The literal `git push upstream <branch>`
+      // form must NOT appear.
+      expect(
+        pushCalls.some((c) =>
+          c.includes('git push git@github.com:upstream/repo.git')
+        )
+      ).toBe(true);
+      expect(pushCalls.some((c) => /git push upstream\b/.test(c))).toBe(false);
       expect(pushCalls.some((c) => c.includes('git push public'))).toBe(false);
+    });
+
+    test('schedule-mode push by URL uses explicit-SHA lease via ls-remote', async () => {
+      mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+        exitCode: 0,
+        stdout: noPublicConfig({
+          schedule: { enabled: true, cron: '0 */6 * * *' },
+        }),
+        stderr: '',
+      });
+      mockResponses.set('git remote get-url upstream', {
+        exitCode: 0,
+        stdout: 'git@github.com:upstream/repo.git',
+        stderr: '',
+      });
+      // Simulate the branch existing on upstream — ls-remote returns a SHA.
+      mockResponses.set('git ls-remote --exit-code', {
+        exitCode: 0,
+        stdout: 'cafef00d\trefs/heads/feature-branch',
+        stderr: '',
+      });
+
+      try {
+        await stageCommand('feature-branch');
+      } catch {
+        // Expected
+      }
+
+      // The push must use --force-with-lease with the explicit SHA,
+      // targeting the upstream URL (not the `upstream` remote name).
+      const pushCalls = execaCalls.filter((c) => c.includes('git push'));
+      expect(
+        pushCalls.some(
+          (c) =>
+            c.includes('git push git@github.com:upstream/repo.git') &&
+            c.includes('--force-with-lease=refs/heads/feature-branch:cafef00d')
+        )
+      ).toBe(true);
     });
   });
 

--- a/tests/setup-args.test.ts
+++ b/tests/setup-args.test.ts
@@ -12,6 +12,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: 'b-private',
       organization: undefined,
       publicForkRepoName: undefined,
+      noPublic: false,
     });
   });
 
@@ -23,6 +24,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: 'lib-vendor',
       organization: 'acme',
       publicForkRepoName: undefined,
+      noPublic: false,
     });
   });
 
@@ -32,6 +34,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: 'r-priv',
       organization: 'corp',
       publicForkRepoName: undefined,
+      noPublic: false,
     });
   });
 
@@ -50,6 +53,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: 'p-private',
       organization: 'o',
       publicForkRepoName: 'p-public',
+      noPublic: false,
     });
 
     expect(
@@ -59,6 +63,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: 'priv',
       organization: undefined,
       publicForkRepoName: 'other-fork',
+      noPublic: false,
     });
   });
 
@@ -69,6 +74,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: undefined,
       organization: 'from-env',
       publicForkRepoName: undefined,
+      noPublic: false,
     });
   });
 
@@ -79,6 +85,7 @@ describe('parseSetupCliArgs', () => {
       privateMirrorName: undefined,
       organization: 'flag',
       publicForkRepoName: undefined,
+      noPublic: false,
     });
   });
 
@@ -104,5 +111,36 @@ describe('parseSetupCliArgs', () => {
     expect(() =>
       parseSetupCliArgs(['https://github.com/a/b', '--fork-name='])
     ).toThrow('--fork-name requires a value');
+  });
+
+  test('--no-public sets noPublic flag', () => {
+    expect(parseSetupCliArgs(['a/b', 'b-private', '--no-public'])).toEqual({
+      upstreamUrl: 'a/b',
+      privateMirrorName: 'b-private',
+      organization: undefined,
+      publicForkRepoName: undefined,
+      noPublic: true,
+    });
+  });
+
+  test('--no-public + --fork-name throws (incompatible)', () => {
+    expect(() =>
+      parseSetupCliArgs([
+        'a/b',
+        'b-private',
+        '--no-public',
+        '--fork-name',
+        'foo',
+      ])
+    ).toThrow(/no-public.*cannot be combined.*fork-name/i);
+  });
+
+  test('--no-public coexists with the positional private mirror name', () => {
+    // Positional arg #2 is `privateMirrorName`, not a fork name — only
+    // --fork-name (or --fork-name=) sets `publicForkRepoName`. So
+    // --no-public + a private mirror name must NOT throw.
+    expect(
+      parseSetupCliArgs(['a/b', 'b-private', '--no-public']).noPublic
+    ).toBe(true);
   });
 });

--- a/tests/workflow.test.ts
+++ b/tests/workflow.test.ts
@@ -39,4 +39,28 @@ describe('workflow helpers', () => {
     const workflow = generateSyncWorkflow("0 */6 * * *'\n# injected");
     expect(workflow).toContain("cron: '0 */6 * * *'' # injected'");
   });
+
+  test('standard mode emits public-remote configuration', () => {
+    const workflow = generateSyncWorkflow('0 */6 * * *', 'standard');
+    expect(workflow).toContain('PUBLIC_URL=');
+    expect(workflow).toContain('git remote add public');
+    expect(workflow).toContain('Missing upstream/public URL in venfork-config');
+  });
+
+  test('no-public mode omits public-remote configuration', () => {
+    const workflow = generateSyncWorkflow('0 */6 * * *', 'no-public');
+    expect(workflow).not.toContain('PUBLIC_URL=');
+    expect(workflow).not.toContain('git remote add public');
+    expect(workflow).not.toContain('git remote remove public');
+    expect(workflow).toContain('Missing upstream URL in venfork-config');
+    // Upstream + DISABLE-push guard remain in no-public mode.
+    expect(workflow).toContain('git remote add upstream');
+    expect(workflow).toContain('git remote set-url --push upstream DISABLE');
+  });
+
+  test('default mode is standard (back-compat with single-arg callers)', () => {
+    const explicit = generateSyncWorkflow('0 */6 * * *', 'standard');
+    const implicit = generateSyncWorkflow('0 */6 * * *');
+    expect(implicit).toBe(explicit);
+  });
 });


### PR DESCRIPTION
## Summary

- `venfork setup --no-public` collapses the 3-remote layout (origin/public/upstream) to 2 remotes (origin/upstream) for users whose upstream lives in their own org. Persisted as `mode: 'no-public'` in the `venfork-config` branch so every later command (`clone`, `sync`, `stage`, `status`, scheduled-sync workflow) auto-detects it.
- `venfork stage` in no-public mode pushes the sanitized branch directly to upstream; `--pr` opens an intra-upstream PR (same-repo head, bare branch name).
- `venfork clone` gains `--no-public` and `--upstream <url>` flags for **legacy mirrors** that pre-date the venfork-config branch. When config is present it remains authoritative — flags only fill in when it isn't, and conflict with config raises a clear error rather than silently overriding.

### Why

Today the only way to set up a single-org repo is `--fork-name`, which creates a redundant second repo in the same org and forces every staged branch through a fork→PR round-trip with no audience to hide work from. `--no-public` removes that ceremony when there's no client/vendor split to maintain.

### Notable internals

- `src/config.ts`: `VenforkConfig.mode?: 'standard' | 'no-public'` (back-compat optional). `publicForkUrl` becomes optional and required only in standard mode. `normalizeConfig` rejects `mode/publicForkUrl` mismatches so a hand-edited config can't end up contradictory.
- `src/commands.ts`: `StagingPlan` refactored from `publicUrl/publicRepoPath/publicOwner` to `pushUrl/pushRepoPath/pushOwner/pushRemote/noPublic` so the same plan drives both standard and no-public push paths. `createUpstreamPr` switches between cross-repo (`owner:branch`) and same-repo (`branch`) heads.
- `src/workflow.ts`: `generateSyncWorkflow(cron, mode)` emits a 2-remote setup script in no-public mode; back-compat one-arg signature still works.

## Test plan

- [x] `bun run check` — Biome clean.
- [x] `bunx tsc --noEmit` — typecheck clean.
- [x] `bun test` — 263 pass, 6 e2e-skip, 0 fail (up from 239 pre-change). New tests cover: `--no-public` parser + conflict; `setupCommand` skips `gh repo fork` and writes correct config; `syncCommand` skips public fetch/push; `stageCommand` pushes to upstream remote; `statusCommand` doesn't require `public`; `cloneCommand --no-public` skips public detection; workflow YAML omits public-remote block in no-public mode.
- [x] `bun run build` succeeds.
- [ ] **Manual smoke** (suggested before merge): create a throwaway upstream you own, run `venfork setup git@github.com:<your-org>/test-upstream.git --no-public --org <your-org>`, confirm only `origin` + `upstream` remotes, confirm `venfork-config` JSON has `"mode": "no-public"` and no `publicForkUrl`, then `venfork stage feat/x --pr` and confirm a same-repo PR opens on upstream.
- [ ] **Back-compat regression**: clone an existing standard-mode mirror; confirm 3-remote setup still works (config without `mode` defaults to `'standard'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)