### PR TITLE
feat: preserve allowlist for mirror-only files across sync

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -257,7 +257,7 @@ async function listWorkflowFiles(cwd: string): Promise<string[]> {
   const result = await $({
     cwd,
     reject: false,
-  })`git ls-tree -r --name-only HEAD ${WORKFLOWS_DIR}`;
+  })`git ls-tree -r --name-only HEAD -- ${WORKFLOWS_DIR}`;
   if (result.exitCode !== 0 || !result.stdout.trim()) {
     return [];
   }
@@ -325,7 +325,7 @@ async function applyMirrorPlusOneCommit(args: {
         path.join(tempDir, SYNC_WORKFLOW_PATH),
         generateSyncWorkflow(schedule.cron, schedule.mode)
       );
-      await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
+      await $({ cwd: tempDir })`git add -- ${SYNC_WORKFLOW_PATH}`;
 
       // Filter upstream workflow files as part of the managed "+1" commit.
       // Precedence: enabledWorkflows allowlist > disabledWorkflows blocklist.
@@ -344,7 +344,7 @@ async function applyMirrorPlusOneCommit(args: {
             await $({
               cwd: tempDir,
               reject: false,
-            })`git rm --quiet --ignore-unmatch ${workflowFile}`;
+            })`git rm --quiet --ignore-unmatch -- ${workflowFile}`;
           }
         }
       }
@@ -396,7 +396,7 @@ async function applyMirrorPlusOneCommit(args: {
         if (treeMode === '100755') {
           await chmod(targetPath, 0o755);
         }
-        await $({ cwd: tempDir })`git add ${preservePath}`;
+        await $({ cwd: tempDir })`git add -- ${preservePath}`;
       }
     }
 
@@ -445,18 +445,20 @@ async function changedFilesInCommit(
 }
 
 /**
- * Returns true when every file changed by `ref` is in the preserve allowlist.
+ * Returns true when every file in `changedFiles` is in the preserve allowlist.
  * Used by sync's divergence check to allow user-authored mirror-only commits
  * (e.g. a caller workflow) ahead of upstream — as long as every changed file
  * is something the user has explicitly opted into preserving.
+ *
+ * Takes pre-computed `changedFiles` rather than fetching them itself so the
+ * caller can amortize the `git diff-tree` invocation across this predicate
+ * AND the divergence-error file collection. Pure / synchronous: no I/O.
  */
-async function isPreservedCommit(
-  ref: string,
-  preserveList: string[],
-  cwd?: string
-): Promise<boolean> {
+function isPreservedCommit(
+  changedFiles: string[],
+  preserveList: string[]
+): boolean {
   if (preserveList.length === 0) return false;
-  const changedFiles = await changedFilesInCommit(ref, cwd);
   if (changedFiles.length === 0) return false;
   const allowed = new Set(preserveList);
   return changedFiles.every((file) => allowed.has(file));
@@ -479,13 +481,13 @@ async function updateWorkflowOnOriginDefault(
       await $({
         cwd: tempDir,
         reject: false,
-      })`git rm --quiet --ignore-unmatch ${SYNC_WORKFLOW_PATH}`;
+      })`git rm --quiet --ignore-unmatch -- ${SYNC_WORKFLOW_PATH}`;
     } else {
       await mkdir(path.join(tempDir, '.github', 'workflows'), {
         recursive: true,
       });
       await writeFile(path.join(tempDir, SYNC_WORKFLOW_PATH), workflowContent);
-      await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
+      await $({ cwd: tempDir })`git add -- ${SYNC_WORKFLOW_PATH}`;
     }
 
     const stagedDiff = await $({
@@ -1480,14 +1482,15 @@ export async function syncCommand(
         const files = new Set<string>();
         for (const commit of divergentCommits) {
           if (await isManagedCommit(commit, options?.cwd)) continue;
-          if (
-            allowPreserved &&
-            (await isPreservedCommit(commit, preserveList, options?.cwd))
-          ) {
+          // Compute the changed files once — both the preserve check and the
+          // divergence-error file aggregation want the same list, and
+          // `git diff-tree` isn't free.
+          const commitFiles = await changedFilesInCommit(commit, options?.cwd);
+          if (allowPreserved && isPreservedCommit(commitFiles, preserveList)) {
             continue;
           }
           count += 1;
-          for (const file of await changedFilesInCommit(commit, options?.cwd)) {
+          for (const file of commitFiles) {
             files.add(file);
           }
         }
@@ -1532,9 +1535,29 @@ export async function syncCommand(
             .map((f) => `  • ${f}`)
             .join('\n')}`
         );
-        sections.push(
-          `If these are mirror-only files you want to keep across sync, add them to preserve:\n  venfork preserve add ${originDivergence.files.join(' ')}`
-        );
+        // Only suggest preserve for paths the validator would actually
+        // accept — otherwise the copy/paste command line would fail.
+        // If every divergent path is invalid for preserve, suppress the hint
+        // entirely (rebase/force-sync below still apply).
+        const validForPreserve: string[] = [];
+        const invalidForPreserve: string[] = [];
+        for (const file of originDivergence.files) {
+          if (normalizePreservePath(file) !== null) {
+            validForPreserve.push(file);
+          } else {
+            invalidForPreserve.push(file);
+          }
+        }
+        if (validForPreserve.length > 0) {
+          sections.push(
+            `If these are mirror-only files you want to keep across sync, add them to preserve:\n  venfork preserve add ${validForPreserve.join(' ')}`
+          );
+          if (invalidForPreserve.length > 0) {
+            sections.push(
+              `(skipped from the hint — paths can't be expressed in the preserve allowlist: ${invalidForPreserve.join(', ')})`
+            );
+          }
+        }
       }
       sections.push(
         `Otherwise:\n- Rebase or cherry-pick to a feature branch before running sync\n- Force-sync (DESTRUCTIVE — permanently discards the commits): git push origin upstream/${defaultBranch}:refs/heads/${defaultBranch} -f`
@@ -1826,8 +1849,9 @@ export async function workflowsCommand(
 
 /**
  * Preserve command: manage the `preserve` allowlist of mirror-only file paths
- * carried forward by `venfork sync`. Additive-only — there's no "deny preserve"
- * concept, since preserve already opts into protection rather than out of it.
+ * carried forward by `venfork sync`. Allowlist-only / opt-in: there's no
+ * "deny preserve" concept (entries can still be added, removed, or cleared
+ * — only the deny-direction has no semantics).
  */
 export async function preserveCommand(
   action: 'list' | 'add' | 'remove' | 'clear',

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -69,8 +69,23 @@ async function confirmOrAutoYes(opts: {
 }
 
 const SYNC_WORKFLOW_PATH = getSyncWorkflowPath();
-const WORKFLOW_COMMIT_MESSAGE =
-  'chore: add/update scheduled sync workflow (venfork)';
+/**
+ * Subject line emitted on every venfork-managed "+1 commit" — both the
+ * scheduled-workflow case and the preserve-only case. Generalized from the
+ * original "scheduled sync workflow" wording because the same commit can now
+ * carry preserve content with no workflow involvement; an honest subject
+ * keeps `git log` readable and lets `isManagedCommit` rely on a single
+ * canonical match without misclassifying preserve-only commits.
+ */
+const MANAGED_COMMIT_MESSAGE = 'chore: venfork-managed mirror commit';
+/**
+ * Subjects emitted by older venfork versions for the same "+1 commit" role.
+ * Recognized by `isManagedCommit` so existing mirrors don't suddenly classify
+ * historical managed commits as user-authored divergence after upgrading.
+ */
+const LEGACY_MANAGED_COMMIT_MESSAGES: readonly string[] = [
+  'chore: add/update scheduled sync workflow (venfork)',
+];
 const WORKFLOWS_DIR = '.github/workflows';
 const VENFORK_BOT_NAME = 'venfork-bot';
 const VENFORK_BOT_EMAIL = 'venfork-bot@users.noreply.github.com';
@@ -133,18 +148,24 @@ async function commitTouchesWorkflowPath(
 }
 
 /**
- * Internal workflow commit marker used by the mirror "+1 commit" model.
+ * Detects the venfork-managed "+1 commit" so sync's divergence check and
+ * stage's cherry-pick filter can skip it without losing user work.
  *
- * We identify this commit by its deterministic message and also accept commits
- * that touch the managed `venfork-sync.yml` plus only sibling files under
- * `.github/workflows/` — so historical rollouts that bundled extra workflow
- * files alongside the managed one are still classified as managed, while
- * user-authored commits to *other* workflow files (e.g. ci.yml) are preserved.
+ * Three signals all classify a commit as managed:
+ *  1. Subject matches the current `MANAGED_COMMIT_MESSAGE`.
+ *  2. Subject matches one of `LEGACY_MANAGED_COMMIT_MESSAGES` — covers
+ *     mirrors created before the message was generalized.
+ *  3. Path heuristic: commit touches the managed `venfork-sync.yml` and
+ *     reaches no further than `.github/workflows/`. This rescues historical
+ *     rollouts that bundled extra workflow files alongside the managed one,
+ *     while keeping user-authored commits to *other* workflow files (e.g.
+ *     ci.yml) classified as user content.
  */
-async function isWorkflowCommit(ref: string, cwd?: string): Promise<boolean> {
+async function isManagedCommit(ref: string, cwd?: string): Promise<boolean> {
   const subject = await commitSubject(ref, cwd);
-  if (subject === WORKFLOW_COMMIT_MESSAGE) {
-    return true;
+  if (subject !== null) {
+    if (subject === MANAGED_COMMIT_MESSAGE) return true;
+    if (LEGACY_MANAGED_COMMIT_MESSAGES.includes(subject)) return true;
   }
   return commitTouchesWorkflowPath(ref, cwd);
 }
@@ -381,7 +402,7 @@ async function applyMirrorPlusOneCommit(args: {
 
     await $({
       cwd: tempDir,
-    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit --allow-empty -m ${WORKFLOW_COMMIT_MESSAGE}`;
+    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit --allow-empty -m ${MANAGED_COMMIT_MESSAGE}`;
 
     await $({
       cwd: tempDir,
@@ -477,7 +498,7 @@ async function updateWorkflowOnOriginDefault(
 
     await $({
       cwd: tempDir,
-    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit -m ${WORKFLOW_COMMIT_MESSAGE}`;
+    })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit -m ${MANAGED_COMMIT_MESSAGE}`;
     await $({
       cwd: tempDir,
     })`git push origin HEAD:${defaultBranch} --force-with-lease`;
@@ -576,7 +597,7 @@ async function buildPublicStageHeadWithoutWorkflowCommit(
     // to pull `origin/<default>` back in after a sync rewrite. `--no-merges`
     // still walks *both* sides of any merge, so non-merge content from either
     // side is cherry-picked as normal (workflow commits introduced via the
-    // merged-in side are then filtered by `isWorkflowCommit` below).
+    // merged-in side are then filtered by `isManagedCommit` below).
     // `--topo-order` makes the parent-before-child guarantee explicit (with
     // `--reverse`: ancestors first, descendants last). The default order is
     // pseudo-chronological and can violate topology when commit timestamps
@@ -592,7 +613,7 @@ async function buildPublicStageHeadWithoutWorkflowCommit(
 
     const commitsToPick: string[] = [];
     for (const commit of branchCommits) {
-      if (!(await isWorkflowCommit(commit, repoDir))) {
+      if (!(await isManagedCommit(commit, repoDir))) {
         commitsToPick.push(commit);
       }
     }
@@ -1458,7 +1479,7 @@ export async function syncCommand(
         let count = 0;
         const files = new Set<string>();
         for (const commit of divergentCommits) {
-          if (await isWorkflowCommit(commit, options?.cwd)) continue;
+          if (await isManagedCommit(commit, options?.cwd)) continue;
           if (
             allowPreserved &&
             (await isPreservedCommit(commit, preserveList, options?.cwd))
@@ -1850,7 +1871,7 @@ export async function preserveCommand(
       const cleaned = normalizePreservePath(candidate);
       if (!cleaned) {
         throw new Error(
-          `Invalid preserve path '${candidate}': must be a relative path with no leading '/' or '..' segments.`
+          `Invalid preserve path '${candidate}': must be a clean relative path (no leading '/', no '..' / '.' / empty segments, no backslashes, NUL bytes, Windows drive prefixes, or whitespace).`
         );
       }
       validated.push(cleaned);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -128,10 +128,12 @@ async function commitTouchesWorkflowPath(
   if (filesResult.exitCode !== 0) {
     return false;
   }
+  // Same line-handling rule as `changedFilesInCommit`: only strip a
+  // trailing CR (CRLF on Windows checkouts), not arbitrary whitespace.
   const changedFiles = filesResult.stdout
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+    .map((line) => line.replace(/\r$/, ''))
+    .filter((line) => line !== '');
   if (!changedFiles.length) {
     return false;
   }
@@ -438,10 +440,14 @@ async function changedFilesInCommit(
     reject: false,
   })`git diff-tree -r --no-commit-id --name-only -m --first-parent ${ref}`;
   if (result.exitCode !== 0) return [];
+  // Strip only a trailing CR (CRLF on Windows checkouts), not arbitrary
+  // whitespace — git path entries can in principle contain leading/trailing
+  // spaces, and `trim()` would silently mangle them. Empty lines after the
+  // CR strip are dropped.
   return result.stdout
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+    .map((line) => line.replace(/\r$/, ''))
+    .filter((line) => line !== '');
 }
 
 /**
@@ -450,17 +456,16 @@ async function changedFilesInCommit(
  * (e.g. a caller workflow) ahead of upstream — as long as every changed file
  * is something the user has explicitly opted into preserving.
  *
- * Takes pre-computed `changedFiles` rather than fetching them itself so the
- * caller can amortize the `git diff-tree` invocation across this predicate
- * AND the divergence-error file collection. Pure / synchronous: no I/O.
+ * Takes pre-computed `changedFiles` AND a pre-built `allowed` Set so the
+ * caller can amortize both the `git diff-tree` invocation and the Set
+ * construction across multiple commits. Pure / synchronous: no I/O.
  */
 function isPreservedCommit(
   changedFiles: string[],
-  preserveList: string[]
+  allowed: Set<string>
 ): boolean {
-  if (preserveList.length === 0) return false;
+  if (allowed.size === 0) return false;
   if (changedFiles.length === 0) return false;
-  const allowed = new Set(preserveList);
   return changedFiles.every((file) => allowed.has(file));
 }
 
@@ -1465,6 +1470,10 @@ export async function syncCommand(
     // preserved-only commit on origin is expected and benign, but the same
     // shape on public would mean someone pushed to public outside venfork —
     // which is a real divergence we want to abort on.
+    // Build the allowlist Set once outside the per-remote loop — both
+    // origin and public divergence checks reuse it across however many
+    // divergent commits each remote has.
+    const preserveAllowed = new Set(preserveList);
     const checkDivergence = async (
       remote: string,
       allowPreserved: boolean
@@ -1486,7 +1495,10 @@ export async function syncCommand(
           // divergence-error file aggregation want the same list, and
           // `git diff-tree` isn't free.
           const commitFiles = await changedFilesInCommit(commit, options?.cwd);
-          if (allowPreserved && isPreservedCommit(commitFiles, preserveList)) {
+          if (
+            allowPreserved &&
+            isPreservedCommit(commitFiles, preserveAllowed)
+          ) {
             continue;
           }
           count += 1;
@@ -1895,7 +1907,7 @@ export async function preserveCommand(
       const cleaned = normalizePreservePath(candidate);
       if (!cleaned) {
         throw new Error(
-          `Invalid preserve path '${candidate}': must be a clean relative path (no leading '/', no '..' / '.' / empty segments, no backslashes, NUL bytes, Windows drive prefixes, or whitespace).`
+          `Invalid preserve path '${candidate}': must be a clean relative path (no leading '/' or '-', no '..' / '.' / empty segments, no backslashes, NUL bytes, Windows drive prefixes, or whitespace).`
         );
       }
       validated.push(cleaned);

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { access, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import * as p from '@clack/prompts';
@@ -7,6 +7,7 @@ import { $ } from 'execa';
 import {
   createConfigBranch,
   fetchVenforkConfig,
+  normalizePreservePath,
   readVenforkConfigFromRepo,
   updateVenforkConfig,
   type VenforkConfig,
@@ -255,14 +256,34 @@ async function remoteBranchExists(
   return result.exitCode === 0;
 }
 
-async function applyScheduledWorkflowCommit(
-  defaultBranch: string,
-  cron: string,
-  enabledWorkflows: string[],
-  disabledWorkflows: string[],
-  mode: 'standard' | 'no-public',
-  cwd?: string
-): Promise<void> {
+/**
+ * Re-stamp `origin/<defaultBranch>` as `upstream/<defaultBranch>` plus one
+ * deterministic "+1 commit" containing the managed sync workflow (when
+ * scheduled) and any preserved mirror-only files. Force-pushes the result.
+ *
+ * `previousMirrorTip` is the commit-ish to read preserve sources from
+ * (typically captured from `git rev-parse origin/<defaultBranch>` *before*
+ * sync's force-push runs). Pass an empty string when no previous tip exists
+ * (first sync); preserve must be empty in that case.
+ */
+async function applyMirrorPlusOneCommit(args: {
+  defaultBranch: string;
+  schedule: { cron: string; mode: 'standard' | 'no-public' } | null;
+  enabledWorkflows: string[];
+  disabledWorkflows: string[];
+  preserve: string[];
+  previousMirrorTip: string;
+  cwd?: string;
+}): Promise<void> {
+  const {
+    defaultBranch,
+    schedule,
+    enabledWorkflows,
+    disabledWorkflows,
+    preserve,
+    previousMirrorTip,
+    cwd,
+  } = args;
   const repoDir = cwd ?? process.cwd();
   const tempDir = await mkdtemp(path.join(os.tmpdir(), 'venfork-sync-'));
   const allowlist = normalizeWorkflowList(enabledWorkflows);
@@ -274,34 +295,87 @@ async function applyScheduledWorkflowCommit(
     await $({
       cwd: repoDir,
     })`git worktree add --detach ${tempDir} upstream/${defaultBranch}`;
-    await mkdir(path.join(tempDir, '.github', 'workflows'), {
-      recursive: true,
-    });
-    await writeFile(
-      path.join(tempDir, SYNC_WORKFLOW_PATH),
-      generateSyncWorkflow(cron, mode)
-    );
-    await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
 
-    // Filter upstream workflow files as part of the managed "+1" commit.
-    // Precedence: enabledWorkflows allowlist > disabledWorkflows blocklist.
-    if (allowlist.length > 0 || blocklist.length > 0) {
-      const workflowFiles = await listWorkflowFiles(tempDir);
-      for (const workflowFile of workflowFiles) {
-        if (workflowFile === SYNC_WORKFLOW_PATH) {
+    if (schedule) {
+      await mkdir(path.join(tempDir, '.github', 'workflows'), {
+        recursive: true,
+      });
+      await writeFile(
+        path.join(tempDir, SYNC_WORKFLOW_PATH),
+        generateSyncWorkflow(schedule.cron, schedule.mode)
+      );
+      await $({ cwd: tempDir })`git add ${SYNC_WORKFLOW_PATH}`;
+
+      // Filter upstream workflow files as part of the managed "+1" commit.
+      // Precedence: enabledWorkflows allowlist > disabledWorkflows blocklist.
+      if (allowlist.length > 0 || blocklist.length > 0) {
+        const workflowFiles = await listWorkflowFiles(tempDir);
+        for (const workflowFile of workflowFiles) {
+          if (workflowFile === SYNC_WORKFLOW_PATH) {
+            continue;
+          }
+          const base = path.basename(workflowFile);
+          const shouldKeep =
+            allowlist.length > 0
+              ? allowlist.includes(base)
+              : !blocklist.includes(base);
+          if (!shouldKeep) {
+            await $({
+              cwd: tempDir,
+              reject: false,
+            })`git rm --quiet --ignore-unmatch ${workflowFile}`;
+          }
+        }
+      }
+    }
+
+    if (preserve.length > 0) {
+      if (!previousMirrorTip) {
+        throw new Error(
+          `Cannot preserve files: no previous origin/${defaultBranch} tip to read from.\n` +
+            'Run `venfork sync` once to populate the mirror, then commit your preserved files and re-run sync.'
+        );
+      }
+      for (const preservePath of preserve) {
+        const upstreamHasIt = await pathExists(
+          path.join(tempDir, preservePath)
+        );
+        if (upstreamHasIt) {
+          p.log.warn(
+            `preserved file '${preservePath}' now exists upstream — using upstream version`
+          );
           continue;
         }
-        const base = path.basename(workflowFile);
-        const shouldKeep =
-          allowlist.length > 0
-            ? allowlist.includes(base)
-            : !blocklist.includes(base);
-        if (!shouldKeep) {
-          await $({
-            cwd: tempDir,
-            reject: false,
-          })`git rm --quiet --ignore-unmatch ${workflowFile}`;
+        const showResult = await $({
+          cwd: repoDir,
+          reject: false,
+          encoding: 'buffer',
+          stripFinalNewline: false,
+        })`git show ${previousMirrorTip}:${preservePath}`;
+        if (showResult.exitCode !== 0) {
+          throw new Error(
+            `Preserved file '${preservePath}' not found on origin/${defaultBranch}.\n` +
+              'Either commit it to the mirror first, or remove the entry with:\n' +
+              `  venfork preserve remove ${preservePath}`
+          );
         }
+        // Preserve the executable bit by reading the tree entry's mode.
+        // `git show <ref>:<path>` only emits content; mode lives on the tree.
+        // Symlinks (120000) and submodules (160000) are out of scope — those
+        // would need plumbing-level handling. Plain files and `+x` files cover
+        // the realistic mirror-only cases (caller workflows, release scripts).
+        const lsTreeResult = await $({
+          cwd: repoDir,
+          reject: false,
+        })`git ls-tree ${previousMirrorTip} -- ${preservePath}`;
+        const treeMode = lsTreeResult.stdout.match(/^(\d+) /)?.[1];
+        const targetPath = path.join(tempDir, preservePath);
+        await mkdir(path.dirname(targetPath), { recursive: true });
+        await writeFile(targetPath, showResult.stdout);
+        if (treeMode === '100755') {
+          await chmod(targetPath, 0o755);
+        }
+        await $({ cwd: tempDir })`git add ${preservePath}`;
       }
     }
 
@@ -319,6 +393,52 @@ async function applyScheduledWorkflowCommit(
     })`git worktree remove --force ${tempDir}`;
     await rm(tempDir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Lists the file paths changed by a single commit. Returns an empty array on
+ * git error or for empty commits. Shared by `isPreservedCommit` and the
+ * divergence-check file collection — both want the same name-only output.
+ *
+ * Uses `diff-tree -m --first-parent` instead of `git show` so merge commits
+ * are diffed against their *first parent* (everything the merge brought in
+ * from the side branch), not the default combined-diff (`--cc`) which only
+ * surfaces conflict-resolution files. Without this, a clean merge that
+ * touches a preserved file would show zero changed files — which would
+ * make `isPreservedCommit` return false and abort sync on a benign merge.
+ */
+async function changedFilesInCommit(
+  ref: string,
+  cwd?: string
+): Promise<string[]> {
+  const cwdOpt = cwd ? { cwd } : {};
+  const result = await $({
+    ...cwdOpt,
+    reject: false,
+  })`git diff-tree -r --no-commit-id --name-only -m --first-parent ${ref}`;
+  if (result.exitCode !== 0) return [];
+  return result.stdout
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Returns true when every file changed by `ref` is in the preserve allowlist.
+ * Used by sync's divergence check to allow user-authored mirror-only commits
+ * (e.g. a caller workflow) ahead of upstream — as long as every changed file
+ * is something the user has explicitly opted into preserving.
+ */
+async function isPreservedCommit(
+  ref: string,
+  preserveList: string[],
+  cwd?: string
+): Promise<boolean> {
+  if (preserveList.length === 0) return false;
+  const changedFiles = await changedFilesInCommit(ref, cwd);
+  if (changedFiles.length === 0) return false;
+  const allowed = new Set(preserveList);
+  return changedFiles.every((file) => allowed.has(file));
 }
 
 async function updateWorkflowOnOriginDefault(
@@ -1312,11 +1432,20 @@ export async function syncCommand(
     const scheduleConfig = config?.schedule;
     const enabledWorkflows = config?.enabledWorkflows ?? [];
     const disabledWorkflows = config?.disabledWorkflows ?? [];
+    const preserveList = config?.preserve ?? [];
 
     // Step 3: Check for divergence
     s.start('Checking for divergent commits');
 
-    const checkDivergence = async (remote: string): Promise<number> => {
+    // `allowPreserved` is asymmetric on purpose: mirror-only files live on
+    // origin (the private mirror) and never get pushed to public. So a
+    // preserved-only commit on origin is expected and benign, but the same
+    // shape on public would mean someone pushed to public outside venfork —
+    // which is a real divergence we want to abort on.
+    const checkDivergence = async (
+      remote: string,
+      allowPreserved: boolean
+    ): Promise<{ count: number; files: string[] }> => {
       try {
         const result = await $({
           ...cwdOpt,
@@ -1326,55 +1455,90 @@ export async function syncCommand(
           .map((line) => line.trim())
           .filter(Boolean);
 
-        let userFacingDivergence = 0;
+        let count = 0;
+        const files = new Set<string>();
         for (const commit of divergentCommits) {
-          if (!(await isWorkflowCommit(commit, options?.cwd))) {
-            userFacingDivergence += 1;
+          if (await isWorkflowCommit(commit, options?.cwd)) continue;
+          if (
+            allowPreserved &&
+            (await isPreservedCommit(commit, preserveList, options?.cwd))
+          ) {
+            continue;
+          }
+          count += 1;
+          for (const file of await changedFilesInCommit(commit, options?.cwd)) {
+            files.add(file);
           }
         }
-        return userFacingDivergence;
+        return { count, files: Array.from(files).sort() };
       } catch {
         // Remote branch might not exist yet (first sync)
-        return 0;
+        return { count: 0, files: [] };
       }
     };
 
-    const originDivergence = await checkDivergence('origin');
-    const publicDivergence = noPublic ? 0 : await checkDivergence('public');
+    const originDivergence = await checkDivergence('origin', true);
+    const publicDivergence = noPublic
+      ? { count: 0, files: [] as string[] }
+      : await checkDivergence('public', false);
 
     s.stop('Checked for divergence');
 
     // Step 4: Warn if divergent commits exist
-    if (originDivergence > 0 || publicDivergence > 0) {
+    if (originDivergence.count > 0 || publicDivergence.count > 0) {
       const warnings: string[] = [];
-      if (originDivergence > 0) {
+      if (originDivergence.count > 0) {
         warnings.push(
-          `  • origin/${defaultBranch} has ${originDivergence} commit(s) not in upstream`
+          `  • origin/${defaultBranch} has ${originDivergence.count} commit(s) not in upstream`
         );
       }
-      if (publicDivergence > 0) {
+      if (publicDivergence.count > 0) {
         warnings.push(
-          `  • public/${defaultBranch} has ${publicDivergence} commit(s) not in upstream`
+          `  • public/${defaultBranch} has ${publicDivergence.count} commit(s) not in upstream`
         );
       }
+
+      // When origin diverges, surface the changed files and a concrete
+      // `venfork preserve add ...` hint. Most likely cause is a mirror-only
+      // file the user committed directly (or one whose preserve entry was
+      // just removed) — both cases resolve with `preserve add`. Public
+      // divergence does NOT get this hint: preserve doesn't apply to public,
+      // so suggesting it would mislead.
+      const sections: string[] = [warnings.join('\n')];
+      if (originDivergence.files.length > 0) {
+        sections.push(
+          `Files changed by divergent commits on origin/${defaultBranch}:\n${originDivergence.files
+            .map((f) => `  • ${f}`)
+            .join('\n')}`
+        );
+        sections.push(
+          `If these are mirror-only files you want to keep across sync, add them to preserve:\n  venfork preserve add ${originDivergence.files.join(' ')}`
+        );
+      }
+      sections.push(
+        `Otherwise:\n- Rebase or cherry-pick to a feature branch before running sync\n- Force-sync (DESTRUCTIVE — permanently discards the commits): git push origin upstream/${defaultBranch}:refs/heads/${defaultBranch} -f`
+      );
 
       p.log.warn('Divergent commits detected:');
-      p.note(
-        `${warnings.join('\n')}
-
-This suggests commits were made directly to the default branch.
-Force syncing will LOSE these commits.
-
-To preserve them: manually rebase or cherry-pick before running sync.
-To force sync anyway: git push origin upstream/${defaultBranch}:refs/heads/${defaultBranch} -f`,
-        '⚠️  Warning'
-      );
+      p.note(sections.join('\n\n'), '⚠️  Warning');
 
       if (!quiet) {
         p.outro('❌ Sync aborted to prevent data loss');
       }
       process.exit(1);
     }
+
+    // Capture the previous mirror tip BEFORE the force-push so
+    // `applyMirrorPlusOneCommit` can read preserved files from it. After the
+    // push, `origin/<defaultBranch>` (locally and remotely) points at the
+    // upstream tree and the previous mirror state is no longer reachable
+    // through that ref.
+    const prevTipResult = await $({
+      ...cwdOpt,
+      reject: false,
+    })`git rev-parse --verify origin/${defaultBranch}`;
+    const previousMirrorTip =
+      prevTipResult.exitCode === 0 ? prevTipResult.stdout.trim() : '';
 
     // Step 5: Push upstream default branch to origin (and public, in standard mode)
     s.start(
@@ -1394,20 +1558,30 @@ To force sync anyway: git push origin upstream/${defaultBranch}:refs/heads/${def
 
     s.stop(noPublic ? 'Synced to origin' : 'Synced to all remotes');
 
-    // Step 6: Enforce mirror "+1 commit" model for scheduled sync workflow.
-    // Scheduling config lives on `venfork-config`; when enabled we re-stamp
-    // one deterministic workflow commit on top of upstream.
-    if (scheduleConfig?.enabled && scheduleConfig.cron) {
-      s.start('Re-applying scheduled sync workflow commit');
-      await applyScheduledWorkflowCommit(
+    // Step 6: Enforce mirror "+1 commit" model. Runs when schedule is enabled
+    // (writes the managed sync workflow + filters upstream workflows) OR when
+    // preserve is non-empty (carries mirror-only files forward across sync).
+    const scheduleActive = Boolean(
+      scheduleConfig?.enabled && scheduleConfig.cron
+    );
+    if (scheduleActive || preserveList.length > 0) {
+      s.start('Re-applying mirror "+1 commit"');
+      await applyMirrorPlusOneCommit({
         defaultBranch,
-        scheduleConfig.cron,
+        schedule:
+          scheduleActive && scheduleConfig
+            ? {
+                cron: scheduleConfig.cron,
+                mode: noPublic ? 'no-public' : 'standard',
+              }
+            : null,
         enabledWorkflows,
         disabledWorkflows,
-        noPublic ? 'no-public' : 'standard',
-        options?.cwd
-      );
-      s.stop('Scheduled workflow commit normalized');
+        preserve: preserveList,
+        previousMirrorTip,
+        cwd: options?.cwd,
+      });
+      s.stop('Mirror "+1 commit" applied');
     }
 
     if (!quiet) {
@@ -1625,6 +1799,94 @@ export async function workflowsCommand(
   } catch (error) {
     p.log.error(error instanceof Error ? error.message : String(error));
     p.outro('❌ Workflows command failed');
+    process.exit(1);
+  }
+}
+
+/**
+ * Preserve command: manage the `preserve` allowlist of mirror-only file paths
+ * carried forward by `venfork sync`. Additive-only — there's no "deny preserve"
+ * concept, since preserve already opts into protection rather than out of it.
+ */
+export async function preserveCommand(
+  action: 'list' | 'add' | 'remove' | 'clear',
+  paths: string[]
+): Promise<void> {
+  p.intro('🧷 Venfork Preserve');
+  const repoDir = process.cwd();
+
+  try {
+    if (action === 'list') {
+      const config = await readVenforkConfigFromRepo(repoDir);
+      if (!config) {
+        throw new Error('venfork-config branch not found or invalid');
+      }
+      const entries = config.preserve ?? [];
+      if (entries.length === 0) {
+        p.note(
+          'No files preserved. Sync will drop any mirror-only files on every run.',
+          'Preserve Status'
+        );
+      } else {
+        p.note(
+          entries.map((entry) => `- ${entry}`).join('\n'),
+          'Preserved files'
+        );
+      }
+      p.outro('✨ Preserve list shown');
+      return;
+    }
+
+    if (action === 'clear') {
+      await updateVenforkConfig(repoDir, { preserve: null });
+      p.outro(
+        '✨ Preserve list cleared. Run `venfork sync` to apply on the private mirror default branch.'
+      );
+      return;
+    }
+
+    const validated: string[] = [];
+    for (const candidate of paths) {
+      const cleaned = normalizePreservePath(candidate);
+      if (!cleaned) {
+        throw new Error(
+          `Invalid preserve path '${candidate}': must be a relative path with no leading '/' or '..' segments.`
+        );
+      }
+      validated.push(cleaned);
+    }
+
+    const current = (await readVenforkConfigFromRepo(repoDir))?.preserve ?? [];
+
+    if (action === 'add') {
+      const merged = Array.from(new Set([...current, ...validated]));
+      await updateVenforkConfig(repoDir, { preserve: merged });
+      p.note(
+        validated.map((entry) => `- ${entry}`).join('\n'),
+        'Added to preserve list'
+      );
+      p.outro(
+        '✨ Preserve list updated. Commit the file(s) to the mirror default branch (if not already), then run `venfork sync`.'
+      );
+      return;
+    }
+
+    // action === 'remove'
+    const toRemove = new Set(validated);
+    const filtered = current.filter((entry) => !toRemove.has(entry));
+    await updateVenforkConfig(repoDir, {
+      preserve: filtered.length > 0 ? filtered : null,
+    });
+    p.note(
+      validated.map((entry) => `- ${entry}`).join('\n'),
+      'Removed from preserve list'
+    );
+    p.outro(
+      '✨ Preserve list updated. Run `venfork sync` to apply on the private mirror default branch.'
+    );
+  } catch (error) {
+    p.log.error(error instanceof Error ? error.message : String(error));
+    p.outro('❌ Preserve command failed');
     process.exit(1);
   }
 }
@@ -3058,7 +3320,12 @@ venfork issue <stage|pull> <number-or-url> [--title <text>]
     record linkage. No comment sync — the linkage is one-shot.
 
 venfork workflows <status|allow|block|clear> [workflow-file ...]
-  Configure workflow allowlist/blocklist policy in venfork-config`,
+  Configure workflow allowlist/blocklist policy in venfork-config
+
+venfork preserve <list|add|remove|clear> [path ...]
+  Carry mirror-only files (e.g. caller workflows) forward across \`venfork sync\`
+  Each entry is a repo-relative path read from the previous origin tip on every sync
+  Upstream wins on collision; missing source aborts sync until the file is committed`,
     'Available Commands'
   );
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,6 +79,14 @@ export interface VenforkConfig {
   };
   enabledWorkflows?: string[];
   disabledWorkflows?: string[];
+  /**
+   * Allowlist of mirror-only file paths to carry forward across `venfork sync`.
+   * Each entry is a repo-relative path (no leading `/`, no `..` segments).
+   * On sync, every listed path is read from the previous mirror tip
+   * (`origin/<defaultBranch>`) and re-added to the deterministic "+1 commit"
+   * — unless upstream now contains the same path, in which case upstream wins.
+   */
+  preserve?: string[];
   /** Branch -> upstream PR linkage recorded by `venfork stage --pr`. */
   shippedBranches?: Record<string, ShippedBranch>;
   /** Branch -> upstream PR tracking recorded by `venfork pull-request`. */
@@ -106,6 +114,7 @@ export type VenforkConfigPatch = Omit<
   Partial<VenforkConfig>,
   | 'enabledWorkflows'
   | 'disabledWorkflows'
+  | 'preserve'
   | 'shippedBranches'
   | 'pulledPrs'
   | 'shippedIssues'
@@ -113,6 +122,7 @@ export type VenforkConfigPatch = Omit<
 > & {
   enabledWorkflows?: string[] | null;
   disabledWorkflows?: string[] | null;
+  preserve?: string[] | null;
   /**
    * Shallow merge into the existing map. Pass `null` for an entry to delete
    * just that branch, or `null` for the whole field to clear the map.
@@ -329,6 +339,28 @@ function normalizePulledIssue(value: unknown): PulledIssue | null {
   };
 }
 
+/**
+ * Validates a single `preserve` entry: must be a non-empty repo-relative path
+ * with no `..` segments, leading slash, NUL byte, or Windows drive prefix.
+ * Returns the cleaned string, or null if the entry is unusable.
+ */
+export function normalizePreservePath(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.includes('\0')) return null;
+  if (trimmed.startsWith('/')) return null;
+  if (trimmed.includes('\\')) return null;
+  if (/^[A-Za-z]:/.test(trimmed)) return null;
+  const segments = trimmed.split('/');
+  for (const seg of segments) {
+    if (seg === '' || seg === '.' || seg === '..') {
+      return null;
+    }
+  }
+  return trimmed;
+}
+
 function normalizeBranchMap<T>(
   source: Record<string, unknown> | undefined,
   perEntry: (value: unknown) => T | null
@@ -412,6 +444,22 @@ function normalizeConfig(config: VenforkConfig): VenforkConfig | null {
       normalized.disabledWorkflows = cleaned;
     } else {
       delete normalized.disabledWorkflows;
+    }
+  }
+
+  if (normalized.preserve) {
+    const cleaned = Array.from(
+      new Set(
+        normalized.preserve
+          .map((value) => normalizePreservePath(value))
+          .filter((value): value is string => value !== null)
+          .sort()
+      )
+    );
+    if (cleaned.length > 0) {
+      normalized.preserve = cleaned;
+    } else {
+      delete normalized.preserve;
     }
   }
 
@@ -583,6 +631,7 @@ function applyPatchAndNormalize(
   const {
     enabledWorkflows: _enabledWorkflowsPatch,
     disabledWorkflows: _disabledWorkflowsPatch,
+    preserve: _preservePatch,
     shippedBranches: _shippedBranchesPatch,
     pulledPrs: _pulledPrsPatch,
     shippedIssues: _shippedIssuesPatch,
@@ -611,6 +660,12 @@ function applyPatchAndNormalize(
     delete merged.disabledWorkflows;
   } else if (patch.disabledWorkflows !== undefined) {
     merged.disabledWorkflows = patch.disabledWorkflows;
+  }
+
+  if (patch.preserve === null) {
+    delete merged.preserve;
+  } else if (patch.preserve !== undefined) {
+    merged.preserve = patch.preserve;
   }
 
   if (patch.shippedBranches === null) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,7 +81,17 @@ export interface VenforkConfig {
   disabledWorkflows?: string[];
   /**
    * Allowlist of mirror-only file paths to carry forward across `venfork sync`.
-   * Each entry is a repo-relative path (no leading `/`, no `..` segments).
+   *
+   * Each entry must be a clean repo-relative path:
+   *   - no leading `/`
+   *   - no `..`, `.`, or empty path segments
+   *   - no backslashes, NUL bytes, Windows drive prefixes (e.g. `C:`)
+   *   - no whitespace anywhere in the path
+   *
+   * Whitespace is forbidden so the divergence-error hint
+   * (`venfork preserve add <path>`) stays copy/paste-safe without quoting.
+   * Entries that don't match are dropped during config normalization.
+   *
    * On sync, every listed path is read from the previous mirror tip
    * (`origin/<defaultBranch>`) and re-added to the deterministic "+1 commit"
    * — unless upstream now contains the same path, in which case upstream wins.
@@ -340,15 +350,21 @@ function normalizePulledIssue(value: unknown): PulledIssue | null {
 }
 
 /**
- * Validates a single `preserve` entry: must be a non-empty repo-relative path
- * with no `..` segments, leading slash, NUL byte, or Windows drive prefix.
- * Returns the cleaned string, or null if the entry is unusable.
+ * Validates a single `preserve` entry. Rejects (returns null) anything that
+ * isn't a clean repo-relative path: empty/whitespace-only, NUL bytes,
+ * leading `/`, backslashes, Windows drive prefixes, or `..` / `.` / empty
+ * segments. Whitespace anywhere in the value is rejected too — preserve
+ * paths surface verbatim in the divergence-error hint
+ * (`venfork preserve add <path>`), so disallowing whitespace keeps that
+ * copy/paste-safe without quoting and rules out an entire bug class for a
+ * negligible cost (workflow/script paths conventionally don't use spaces).
  */
 export function normalizePreservePath(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
   if (trimmed.includes('\0')) return null;
+  if (/\s/.test(trimmed)) return null;
   if (trimmed.startsWith('/')) return null;
   if (trimmed.includes('\\')) return null;
   if (/^[A-Za-z]:/.test(trimmed)) return null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -364,6 +364,12 @@ function normalizePulledIssue(value: unknown): PulledIssue | null {
  * option (e.g. `git add --all`). Every internal call site already passes
  * paths after `--`, but rejecting up-front means an attacker-controlled or
  * accidentally-malformed entry can't reach those call sites at all.
+ *
+ * IMPORTANT: if you change the rejection rules below, also update:
+ *   - the JSDoc on `VenforkConfig.preserve` (above)
+ *   - the user-facing error message in `preserveCommand` (src/commands.ts)
+ * All three must stay in sync — users see the JSDoc when editing config by
+ * hand, and the error message when running `venfork preserve add`.
  */
 export function normalizePreservePath(value: unknown): string | null {
   if (typeof value !== 'string') return null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -84,6 +84,7 @@ export interface VenforkConfig {
    *
    * Each entry must be a clean repo-relative path:
    *   - no leading `/`
+   *   - no leading `-` (would parse as a flag in `git add`/etc.)
    *   - no `..`, `.`, or empty path segments
    *   - no backslashes, NUL bytes, Windows drive prefixes (e.g. `C:`)
    *   - no whitespace anywhere in the path
@@ -202,7 +203,7 @@ async function writeConfigBranch(
 
     await $({ cwd: tempDir })`git init`;
     await $({ cwd: tempDir })`git checkout --orphan ${CONFIG_BRANCH}`;
-    await $({ cwd: tempDir })`git add ${CONFIG_DIR}/${CONFIG_FILE}`;
+    await $({ cwd: tempDir })`git add -- ${CONFIG_DIR}/${CONFIG_FILE}`;
     await $({
       cwd: tempDir,
     })`git -c user.name=${VENFORK_BOT_NAME} -c user.email=${VENFORK_BOT_EMAIL} commit -m ${commitMessage}`;
@@ -352,12 +353,17 @@ function normalizePulledIssue(value: unknown): PulledIssue | null {
 /**
  * Validates a single `preserve` entry. Rejects (returns null) anything that
  * isn't a clean repo-relative path: empty/whitespace-only, NUL bytes,
- * leading `/`, backslashes, Windows drive prefixes, or `..` / `.` / empty
- * segments. Whitespace anywhere in the value is rejected too — preserve
- * paths surface verbatim in the divergence-error hint
+ * leading `/`, backslashes, Windows drive prefixes, leading `-`, or
+ * `..` / `.` / empty segments. Whitespace anywhere in the value is rejected
+ * too — preserve paths surface verbatim in the divergence-error hint
  * (`venfork preserve add <path>`), so disallowing whitespace keeps that
  * copy/paste-safe without quoting and rules out an entire bug class for a
  * negligible cost (workflow/script paths conventionally don't use spaces).
+ *
+ * Leading `-` is forbidden so a preserved filename can't be parsed as a git
+ * option (e.g. `git add --all`). Every internal call site already passes
+ * paths after `--`, but rejecting up-front means an attacker-controlled or
+ * accidentally-malformed entry can't reach those call sites at all.
  */
 export function normalizePreservePath(value: unknown): string | null {
   if (typeof value !== 'string') return null;
@@ -366,6 +372,7 @@ export function normalizePreservePath(value: unknown): string | null {
   if (trimmed.includes('\0')) return null;
   if (/\s/.test(trimmed)) return null;
   if (trimmed.startsWith('/')) return null;
+  if (trimmed.startsWith('-')) return null;
   if (trimmed.includes('\\')) return null;
   if (/^[A-Za-z]:/.test(trimmed)) return null;
   const segments = trimmed.split('/');

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { parseCloneCliArgs } from './clone-args.js';
 import {
   cloneCommand,
   issueCommand,
+  preserveCommand,
   pullRequestCommand,
   scheduleCommand,
   setupCommand,
@@ -15,6 +16,7 @@ import {
   workflowsCommand,
 } from './commands.js';
 import { parseIssueCliArgs } from './issue-args.js';
+import { parsePreserveCliArgs } from './preserve-args.js';
 import { parsePullRequestCliArgs } from './pull-request-args.js';
 import { parseSetupCliArgs } from './setup-args.js';
 import { parseStageCliArgs } from './stage-args.js';
@@ -81,6 +83,11 @@ async function main(): Promise<void> {
     case 'workflows': {
       const parsed = parseWorkflowsCliArgs(args.slice(1));
       await workflowsCommand(parsed.action, parsed.workflows);
+      break;
+    }
+    case 'preserve': {
+      const parsed = parsePreserveCliArgs(args.slice(1));
+      await preserveCommand(parsed.action, parsed.paths);
       break;
     }
     case 'pull-request': {

--- a/src/preserve-args.ts
+++ b/src/preserve-args.ts
@@ -1,0 +1,37 @@
+export type ParsedPreserveArgs = {
+  action: 'list' | 'add' | 'remove' | 'clear';
+  paths: string[];
+};
+
+/**
+ * Parse `venfork preserve ...` argv after the `preserve` token.
+ *
+ * Path entries are taken verbatim — no comma-splitting — so paths that
+ * happen to contain a comma still work. Pass each path as a separate argv
+ * entry (`venfork preserve add path/one path/two`).
+ */
+export function parsePreserveCliArgs(
+  preserveArgs: string[]
+): ParsedPreserveArgs {
+  const actionRaw = preserveArgs[0] ?? 'list';
+
+  if (actionRaw === 'list') {
+    return { action: 'list', paths: [] };
+  }
+
+  if (actionRaw === 'clear') {
+    return { action: 'clear', paths: [] };
+  }
+
+  if (actionRaw === 'add' || actionRaw === 'remove') {
+    const values = preserveArgs.slice(1).filter((entry) => entry.length > 0);
+    if (values.length === 0) {
+      throw new Error(
+        `Usage: venfork preserve ${actionRaw} <path> [more-paths]`
+      );
+    }
+    return { action: actionRaw, paths: values };
+  }
+
+  throw new Error('Usage: venfork preserve <list|add|remove|clear> [path ...]');
+}

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -553,7 +553,7 @@ describe('syncCommand', () => {
     expect(
       execaCalls.some((cmd) =>
         cmd.includes(
-          'commit --allow-empty -m chore: add/update scheduled sync workflow (venfork)'
+          'commit --allow-empty -m chore: venfork-managed mirror commit'
         )
       )
     ).toBe(true);
@@ -729,7 +729,7 @@ describe('syncCommand', () => {
       execaCalls.some(
         (cmd) =>
           cmd.includes('commit --allow-empty') &&
-          cmd.includes('chore: add/update scheduled sync workflow')
+          cmd.includes('chore: venfork-managed mirror commit')
       )
     ).toBe(false);
   });
@@ -871,6 +871,56 @@ describe('syncCommand', () => {
     const messages = noteCalls.map((n) => n.message).join('\n---\n');
     expect(messages).toContain('venfork preserve add agent.yml');
     expect(messages).toContain('agent.yml');
+  });
+
+  test('legacy "+1 commit" subjects from older venfork versions still classify as managed (no spurious divergence)', async () => {
+    // Older venfork emitted `chore: add/update scheduled sync workflow
+    // (venfork)` for the +1 commit. Mirrors created with that version
+    // still have those subjects in their history. After upgrading, the
+    // divergence check must continue to recognize them — otherwise the
+    // first sync after upgrade aborts with a false-positive on every
+    // mirror in the wild.
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-list upstream/main..origin/main', {
+      exitCode: 0,
+      stdout: 'legacycommit11111\n',
+      stderr: '',
+    });
+    mockResponses.set('git rev-list upstream/main..public/main', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    // Subject = the OLD message string. Must be recognized as managed.
+    mockResponses.set('git log -1 --format=%s legacycommit11111', {
+      exitCode: 0,
+      stdout: 'chore: add/update scheduled sync workflow (venfork)\n',
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    // Sync must NOT have aborted on the legacy-message commit — the
+    // upstream→origin force-push should still happen.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes(
+          'git push origin upstream/main:refs/heads/main --force-with-lease'
+        )
+      )
+    ).toBe(true);
   });
 
   test('divergence check tolerates a commit whose changed files are all preserved', async () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -643,7 +643,7 @@ describe('syncCommand', () => {
     // The preserved file is added in the temp worktree.
     expect(
       execaCalls.some((cmd) =>
-        cmd.includes('git add .github/workflows/caller.yml')
+        cmd.includes('git add -- .github/workflows/caller.yml')
       )
     ).toBe(true);
     // The deterministic commit + force-push happen.
@@ -690,7 +690,9 @@ describe('syncCommand', () => {
     ).toBe(false);
     // git add for the preserved path should NOT be called either.
     expect(
-      execaCalls.some((cmd) => cmd.includes('git add .github/workflows/ci.yml'))
+      execaCalls.some((cmd) =>
+        cmd.includes('git add -- .github/workflows/ci.yml')
+      )
     ).toBe(false);
   });
 
@@ -800,7 +802,7 @@ describe('syncCommand', () => {
     expect(String(agentWrite?.content)).toBe('agent: v2');
 
     // And: agent.yml is `git add`ed, then committed and force-pushed back.
-    expect(execaCalls.some((cmd) => cmd.includes('git add agent.yml'))).toBe(
+    expect(execaCalls.some((cmd) => cmd.includes('git add -- agent.yml'))).toBe(
       true
     );
     expect(

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -23,11 +23,13 @@ type MockResponse =
 const execaCalls: string[] = [];
 const rmCalls: RmCall[] = [];
 const writeFileCalls: WriteFileCall[] = [];
+const noteCalls: Array<{ message: string; title?: string }> = [];
 const signalHandlers = new Map<string, SignalHandler>();
 let shouldHangOnFork = false;
 const mockResponses: Map<string, MockResponse> = new Map();
 let confirmResponse = true; // Default to true for most tests
 let tempDirCounter = 0;
+let accessExists: (filePath: string) => boolean = () => false;
 
 // Store originals
 const originalProcessOn = process.on;
@@ -164,7 +166,11 @@ mock.module('node:fs/promises', () => ({
     rmCalls.push({ path, options });
     return Promise.resolve();
   }),
-  access: mock(() => Promise.reject(new Error('ENOENT'))),
+  access: mock((filePath: string) =>
+    accessExists(filePath)
+      ? Promise.resolve()
+      : Promise.reject(new Error('ENOENT'))
+  ),
 }));
 
 // Mock prompts BEFORE any imports
@@ -174,7 +180,9 @@ mock.module('@clack/prompts', () => ({
     start: mock(() => {}),
     stop: mock(() => {}),
   })),
-  note: mock(() => {}),
+  note: mock((message: string, title?: string) => {
+    noteCalls.push({ message, title });
+  }),
   outro: mock(() => {}),
   cancel: mock(() => {}),
   log: { error: mock(() => {}), warn: mock(() => {}), info: mock(() => {}) },
@@ -224,11 +232,13 @@ beforeEach(() => {
   execaCalls.length = 0;
   rmCalls.length = 0;
   writeFileCalls.length = 0;
+  noteCalls.length = 0;
   signalHandlers.clear();
   shouldHangOnFork = false;
   mockResponses.clear();
   confirmResponse = true; // Reset to true for each test
   tempDirCounter = 0;
+  accessExists = () => false;
 
   // Clear VENFORK_ORG environment variable
   delete process.env.VENFORK_ORG;
@@ -585,6 +595,345 @@ describe('syncCommand', () => {
     expect(
       execaCalls.some((cmd) => cmd.includes('git worktree add --detach'))
     ).toBe(false);
+  });
+
+  test('preserve carries mirror-only files forward across sync', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        preserve: ['.github/workflows/caller.yml'],
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify origin/main', {
+      exitCode: 0,
+      stdout: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+      stderr: '',
+    });
+    mockResponses.set(
+      'git show aaaa1111bbbb2222cccc3333dddd4444eeee5555:.github/workflows/caller.yml',
+      {
+        exitCode: 0,
+        stdout: 'name: caller\non: workflow_dispatch\n',
+        stderr: '',
+      }
+    );
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    // The "+1 commit" path runs even though schedule is disabled.
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git worktree add --detach'))
+    ).toBe(true);
+    // git show is called against the captured previous mirror tip.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes(
+          'git show aaaa1111bbbb2222cccc3333dddd4444eeee5555:.github/workflows/caller.yml'
+        )
+      )
+    ).toBe(true);
+    // The preserved file is added in the temp worktree.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git add .github/workflows/caller.yml')
+      )
+    ).toBe(true);
+    // The deterministic commit + force-push happen.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git push origin HEAD:main --force-with-lease')
+      )
+    ).toBe(true);
+  });
+
+  test('preserve skips paths that already exist upstream (upstream wins)', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        preserve: ['.github/workflows/ci.yml'],
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify origin/main', {
+      exitCode: 0,
+      stdout: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+      stderr: '',
+    });
+    // Pretend the temp worktree (started from upstream) already has the file.
+    accessExists = (p) => p.includes('.github/workflows/ci.yml');
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    // git show against the previous mirror tip should NOT be called for the
+    // colliding path — upstream's version wins, and the carry-forward is skipped.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes(
+          'git show aaaa1111bbbb2222cccc3333dddd4444eeee5555:.github/workflows/ci.yml'
+        )
+      )
+    ).toBe(false);
+    // git add for the preserved path should NOT be called either.
+    expect(
+      execaCalls.some((cmd) => cmd.includes('git add .github/workflows/ci.yml'))
+    ).toBe(false);
+  });
+
+  test('preserve fails loudly when source path is missing on previous mirror tip', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        preserve: ['.github/workflows/missing.yml'],
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify origin/main', {
+      exitCode: 0,
+      stdout: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+      stderr: '',
+    });
+    mockResponses.set(
+      'git show aaaa1111bbbb2222cccc3333dddd4444eeee5555:.github/workflows/missing.yml',
+      { exitCode: 128, stdout: '', stderr: 'fatal: path ... does not exist' }
+    );
+
+    let caught = false;
+    try {
+      await syncCommand('main');
+    } catch {
+      caught = true;
+    }
+
+    // process.exit(1) is mocked to throw — sync should have errored before
+    // creating the deterministic commit on the temp worktree.
+    expect(caught).toBe(true);
+    expect(
+      execaCalls.some(
+        (cmd) =>
+          cmd.includes('commit --allow-empty') &&
+          cmd.includes('chore: add/update scheduled sync workflow')
+      )
+    ).toBe(false);
+  });
+
+  test('preserve carries the user-committed content forward (v2 wins, not v1, not upstream, not absent)', async () => {
+    // Mirror tip already has agent.yml@v1; user commits v2 directly to
+    // origin/main and pushes. Sync runs. Post-sync, the worktree write that
+    // feeds the +1 commit must contain v2 — not v1, not upstream's version,
+    // not absent. This pins the contract that previousMirrorTip is captured
+    // *after* fetch and *before* the force-push, so it sees the user's
+    // most-recent commit.
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        preserve: ['agent.yml'],
+      }),
+      stderr: '',
+    });
+    // Local origin/main (post-fetch) is the SHA of the user's v2 commit.
+    mockResponses.set('git rev-parse --verify origin/main', {
+      exitCode: 0,
+      stdout: 'v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2',
+      stderr: '',
+    });
+    // Reading agent.yml from the v2 SHA returns the user's v2 content.
+    mockResponses.set(
+      'git show v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2:agent.yml',
+      { exitCode: 0, stdout: 'agent: v2', stderr: '' }
+    );
+    mockResponses.set('git ls-tree v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2v2', {
+      exitCode: 0,
+      stdout: '100644 blob deadbeef\tagent.yml\n',
+      stderr: '',
+    });
+    // Divergence check: the v2 commit is on origin (the user's commit).
+    mockResponses.set('git rev-list upstream/main..origin/main', {
+      exitCode: 0,
+      stdout: 'v2v2v2v2v2v2v2v2\n',
+      stderr: '',
+    });
+    mockResponses.set('git rev-list upstream/main..public/main', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set(
+      'git diff-tree -r --no-commit-id --name-only -m --first-parent v2v2v2v2v2v2v2v2',
+      { exitCode: 0, stdout: 'agent.yml\n', stderr: '' }
+    );
+    mockResponses.set('git log -1 --format=%s v2v2v2v2v2v2v2v2', {
+      exitCode: 0,
+      stdout: 'mirror: bump agent to v2\n',
+      stderr: '',
+    });
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    // The write that feeds the deterministic +1 commit must contain v2.
+    const agentWrite = writeFileCalls.find((w) => w.path.endsWith('agent.yml'));
+    expect(agentWrite).toBeDefined();
+    expect(String(agentWrite?.content)).toBe('agent: v2');
+
+    // And: agent.yml is `git add`ed, then committed and force-pushed back.
+    expect(execaCalls.some((cmd) => cmd.includes('git add agent.yml'))).toBe(
+      true
+    );
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes('git push origin HEAD:main --force-with-lease')
+      )
+    ).toBe(true);
+  });
+
+  test('removing a preserve entry re-asserts strictness on the orphaned mirror commit', async () => {
+    // Sequence simulated: previously, `preserve: ['agent.yml']` was set and a
+    // user commit landed on origin (passing divergence under the allowlist).
+    // The user has now run `venfork preserve remove agent.yml`. The commit is
+    // still on origin/main but preserve no longer covers it — divergence
+    // check should flag it and abort. The error must surface the file by
+    // name with a concrete `venfork preserve add` hint, so the user
+    // remembers what they removed.
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        // preserve intentionally absent — the entry was just removed.
+      }),
+      stderr: '',
+    });
+    mockResponses.set('git rev-list upstream/main..origin/main', {
+      exitCode: 0,
+      stdout: 'orphancommit11111\n',
+      stderr: '',
+    });
+    mockResponses.set('git rev-list upstream/main..public/main', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    mockResponses.set('git log -1 --format=%s orphancommit11111', {
+      exitCode: 0,
+      stdout: 'mirror: add agent caller workflow\n',
+      stderr: '',
+    });
+    mockResponses.set(
+      'git diff-tree -r --no-commit-id --name-only -m --first-parent orphancommit11111',
+      { exitCode: 0, stdout: 'agent.yml\n', stderr: '' }
+    );
+
+    let aborted = false;
+    try {
+      await syncCommand('main');
+    } catch {
+      aborted = true;
+    }
+
+    // Sync must abort (process.exit(1) is mocked to throw).
+    expect(aborted).toBe(true);
+    // The upstream→origin force-push must NOT have happened.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes(
+          'git push origin upstream/main:refs/heads/main --force-with-lease'
+        )
+      )
+    ).toBe(false);
+    // The error message must surface the orphaned file with a concrete
+    // `venfork preserve add` hint — the case-by-name guidance the user
+    // needs to recognize "oh, that's the entry I just removed."
+    const messages = noteCalls.map((n) => n.message).join('\n---\n');
+    expect(messages).toContain('venfork preserve add agent.yml');
+    expect(messages).toContain('agent.yml');
+  });
+
+  test('divergence check tolerates a commit whose changed files are all preserved', async () => {
+    mockResponses.set('git show FETCH_HEAD:.venfork/config.json', {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        version: '1',
+        publicForkUrl: 'git@github.com:test/repo.git',
+        upstreamUrl: 'git@github.com:upstream/repo.git',
+        preserve: ['.github/workflows/caller.yml'],
+      }),
+      stderr: '',
+    });
+    // origin has 1 commit ahead of upstream — the user's preserve commit.
+    mockResponses.set('git rev-list upstream/main..origin/main', {
+      exitCode: 0,
+      stdout: 'feedfacecafebabe\n',
+      stderr: '',
+    });
+    mockResponses.set('git rev-list upstream/main..public/main', {
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    });
+    // That commit's changed files: only the preserved path.
+    mockResponses.set(
+      'git diff-tree -r --no-commit-id --name-only -m --first-parent feedfacecafebabe',
+      {
+        exitCode: 0,
+        stdout: '.github/workflows/caller.yml\n',
+        stderr: '',
+      }
+    );
+    // Subject doesn't match the workflow message — would normally count as divergent.
+    mockResponses.set('git log -1 --format=%s feedfacecafebabe', {
+      exitCode: 0,
+      stdout: 'mirror: add caller workflow\n',
+      stderr: '',
+    });
+    mockResponses.set('git rev-parse --verify origin/main', {
+      exitCode: 0,
+      stdout: 'aaaa1111bbbb2222cccc3333dddd4444eeee5555',
+      stderr: '',
+    });
+    mockResponses.set(
+      'git show aaaa1111bbbb2222cccc3333dddd4444eeee5555:.github/workflows/caller.yml',
+      { exitCode: 0, stdout: 'name: caller\n', stderr: '' }
+    );
+
+    try {
+      await syncCommand('main');
+    } catch {
+      // Expected in mocked environment
+    }
+
+    // Sync should NOT have aborted — the upstream-to-origin push happens.
+    expect(
+      execaCalls.some((cmd) =>
+        cmd.includes(
+          'git push origin upstream/main:refs/heads/main --force-with-lease'
+        )
+      )
+    ).toBe(true);
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -161,6 +161,59 @@ describe('updateVenforkConfig', () => {
     );
   });
 
+  test('stores normalized preserve allowlist and round-trips through write', async () => {
+    const updated = await updateVenforkConfig('/tmp/repo', {
+      preserve: [
+        '  .github/workflows/caller.yml ',
+        'docs/MIRROR.md',
+        '.github/workflows/caller.yml',
+      ],
+    });
+
+    expect(updated.preserve).toEqual([
+      '.github/workflows/caller.yml',
+      'docs/MIRROR.md',
+    ]);
+    expect(writeFileCalls.length).toBeGreaterThan(0);
+    expect(writeFileCalls[writeFileCalls.length - 1].content).toContain(
+      '"preserve"'
+    );
+  });
+
+  test('clears preserve list when patch sets it to null', async () => {
+    mockResponses.set(
+      'git show FETCH_HEAD:.venfork/config.json',
+      mockReadResponse({
+        ...baseConfig,
+        preserve: ['.github/workflows/caller.yml'],
+      })
+    );
+
+    const updated = await updateVenforkConfig('/tmp/repo', {
+      preserve: null,
+    });
+
+    expect(updated.preserve).toBeUndefined();
+    expect(writeFileCalls[writeFileCalls.length - 1].content).not.toContain(
+      '"preserve"'
+    );
+  });
+
+  test('drops invalid preserve paths during normalize', async () => {
+    const updated = await updateVenforkConfig('/tmp/repo', {
+      preserve: [
+        '/abs/path',
+        '../escape',
+        'foo/../bar',
+        '.github/workflows/ok.yml',
+        '',
+      ],
+    });
+
+    // Only the well-formed relative path survives.
+    expect(updated.preserve).toEqual(['.github/workflows/ok.yml']);
+  });
+
   test('records and merges shippedBranches entries', async () => {
     // First ship: insert one entry.
     const first = await updateVenforkConfig('/tmp/repo', {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -215,6 +215,11 @@ describe('updateVenforkConfig', () => {
         // Backslashes and Windows drive prefixes are rejected too.
         'win\\path.yml',
         'C:/abs.yml',
+        // Leading `-` is rejected so a filename can't be parsed as a git
+        // option (e.g. `git add --all`). All internal call sites use `--`,
+        // but rejecting up-front means a malformed entry can't reach them.
+        '-rf',
+        '--all',
       ],
     });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -207,6 +207,14 @@ describe('updateVenforkConfig', () => {
         'foo/../bar',
         '.github/workflows/ok.yml',
         '',
+        // Whitespace anywhere in the path is rejected — keeps the
+        // `venfork preserve add <path>` divergence-error hint
+        // copy/paste-safe without any quoting.
+        'has space.yml',
+        'tabs\there.yml',
+        // Backslashes and Windows drive prefixes are rejected too.
+        'win\\path.yml',
+        'C:/abs.yml',
       ],
     });
 

--- a/tests/preserve-args.test.ts
+++ b/tests/preserve-args.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test';
+import { parsePreserveCliArgs } from '../src/preserve-args.js';
+
+describe('parsePreserveCliArgs', () => {
+  test('defaults to list', () => {
+    expect(parsePreserveCliArgs([])).toEqual({
+      action: 'list',
+      paths: [],
+    });
+  });
+
+  test('parses list explicitly', () => {
+    expect(parsePreserveCliArgs(['list'])).toEqual({
+      action: 'list',
+      paths: [],
+    });
+  });
+
+  test('parses add with multiple paths', () => {
+    expect(
+      parsePreserveCliArgs([
+        'add',
+        '.github/workflows/caller.yml',
+        'docs/MIRROR.md',
+      ])
+    ).toEqual({
+      action: 'add',
+      paths: ['.github/workflows/caller.yml', 'docs/MIRROR.md'],
+    });
+  });
+
+  test('parses remove with multiple paths', () => {
+    expect(
+      parsePreserveCliArgs(['remove', '.github/workflows/caller.yml'])
+    ).toEqual({
+      action: 'remove',
+      paths: ['.github/workflows/caller.yml'],
+    });
+  });
+
+  test('parses clear', () => {
+    expect(parsePreserveCliArgs(['clear'])).toEqual({
+      action: 'clear',
+      paths: [],
+    });
+  });
+
+  test('does not split paths on commas', () => {
+    expect(parsePreserveCliArgs(['add', 'a,b/c.yml'])).toEqual({
+      action: 'add',
+      paths: ['a,b/c.yml'],
+    });
+  });
+
+  test('throws when add has no paths', () => {
+    expect(() => parsePreserveCliArgs(['add'])).toThrow();
+  });
+
+  test('throws when remove has no paths', () => {
+    expect(() => parsePreserveCliArgs(['remove'])).toThrow();
+  });
+
+  test('throws on unknown action', () => {
+    expect(() => parsePreserveCliArgs(['nuke'])).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- New `preserve: string[]` field in venfork-config + `venfork preserve <list|add|remove|clear>` CLI for carrying mirror-only files (e.g. caller workflows, release scripts) across `venfork sync`.
- Sync captures `origin/<defaultBranch>` before the force-push and re-applies each preserved path into the deterministic "+1 commit." Upstream wins on collision (warns); missing source aborts with a `venfork preserve remove <path>` recovery hint.
- Divergence check now tolerates user-authored mirror-only commits on origin when every changed file is in the preserve allowlist — public stays strict.
- Divergence error message lists the changed files and emits a concrete `venfork preserve add <path…>` suggestion. Force-sync hint marked DESTRUCTIVE.

## Why
`enabledWorkflows` is an upstream-side filter — it cannot preserve files that aren't in upstream. Caller workflows and other mirror-only files were silently dropped on every sync. `preserve` closes that gap with a deliberate exact-paths allowlist (no globs in v1; the discipline is the feature).

## Notable details
- **Executable bit preserved** via `git ls-tree` + `chmod 755` for `100755` entries. Symlinks/submodules are out of scope.
- **Merge-commit handling**: `changedFilesInCommit` uses `git diff-tree -m --first-parent` so a clean merge whose merged-in side touches a preserved file is classified correctly (the default `--cc` would emit zero files and break the divergence relaxation).
- **Refactor**: `applyScheduledWorkflowCommit` → `applyMirrorPlusOneCommit`, now runs whenever schedule OR preserve is active. Schedule still drives the managed sync workflow; preserve is independent.
- **Asymmetric divergence** (origin permissive, public strict) is documented inline.

## Out of scope (intentionally)
Globs, directory entries, commit pinning, content templating, auto-pruning stale entries, distinguishing "never committed" from "previously preserved, now removed" (both error).

## Test plan
- [x] `bun test` — 283 unit tests pass, 6 e2e skip
- [x] `bun run check` — biome clean
- [x] `bunx tsc --noEmit` — typecheck clean
- [x] New tests cover: parser, config round-trip, invalid-path normalize, sync happy path, missing-source error, upstream collision, **user-content-survives** (v2 wins, not v1, not upstream, not absent), **remove-reasserts-strictness** (post-removal sync aborts with named-file hint), divergence-tolerates-preserved-commit
- [ ] Manual smoke on a throwaway mirror once 0.8.0 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)