### PR TITLE
feat: seed mirror with commit-batched pushes for large upstreams

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -66,12 +66,16 @@ const NET_ENV = {
  *
  * @param cwd Working directory for the command, or undefined for the default.
  */
-function netExec(cwd?: string) {
+function netExec(cwd?: string, opts?: { captureOutput?: boolean }) {
+  const captureOutput = opts?.captureOutput === true;
   return $({
     ...(cwd ? { cwd } : {}),
     env: NET_ENV,
     timeout: GIT_NET_TIMEOUT_MS,
-    stdio: ['ignore', 'inherit', 'inherit'],
+    stdio: captureOutput
+      ? ['ignore', 'pipe', 'pipe']
+      : ['ignore', 'inherit', 'inherit'],
+    ...(captureOutput ? { buffer: false } : {}),
   });
 }
 
@@ -169,7 +173,6 @@ function isTransientPushError(err: unknown): boolean {
     'service unavailable',
     'the remote end hung up',
     'unexpected disconnect',
-    'rpc failed',
     'early eof',
     'connection reset',
     'connection timed out',
@@ -179,6 +182,57 @@ function isTransientPushError(err: unknown): boolean {
     'transfer closed',
   ];
   return transient.some((p) => text.includes(p));
+}
+
+const PUSH_ERROR_TAIL_CHARS = 16_384;
+
+function appendTail(text: string, chunk: string): string {
+  const next = text + chunk;
+  return next.length > PUSH_ERROR_TAIL_CHARS
+    ? next.slice(-PUSH_ERROR_TAIL_CHARS)
+    : next;
+}
+
+async function pushSeedRef(
+  tempDir: string,
+  httpsUrl: string,
+  src: string,
+  branch: string
+): Promise<void> {
+  const push = netExec(tempDir, {
+    captureOutput: true,
+  })`git ${SEED_PUSH_CONFIG} push --force --no-thin --progress ${httpsUrl} ${src}:refs/heads/${branch}`;
+  let stdoutTail = '';
+  let stderrTail = '';
+  push.stdout?.on('data', (chunk: string | Buffer) => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString();
+    process.stdout.write(text);
+    stdoutTail = appendTail(stdoutTail, text);
+  });
+  push.stderr?.on('data', (chunk: string | Buffer) => {
+    const text = typeof chunk === 'string' ? chunk : chunk.toString();
+    process.stderr.write(text);
+    stderrTail = appendTail(stderrTail, text);
+  });
+
+  try {
+    await push;
+  } catch (err) {
+    const e = err as { stdout?: unknown; stderr?: unknown };
+    if (
+      (typeof e.stdout !== 'string' || e.stdout.length === 0) &&
+      stdoutTail.length > 0
+    ) {
+      e.stdout = stdoutTail;
+    }
+    if (
+      (typeof e.stderr !== 'string' || e.stderr.length === 0) &&
+      stderrTail.length > 0
+    ) {
+      e.stderr = stderrTail;
+    }
+    throw err;
+  }
 }
 
 /**
@@ -226,10 +280,7 @@ async function seedMirrorInChunks(
           `Pushing ${label} to private mirror repository` +
             (attempt > 1 ? ` (attempt ${attempt})` : ''),
           `Pushed ${label}`,
-          () =>
-            netExec(
-              tempDir
-            )`git ${SEED_PUSH_CONFIG} push --force --no-thin --progress ${httpsUrl} ${src}:refs/heads/${branch}`
+          () => pushSeedRef(tempDir, httpsUrl, src, branch)
         );
         return;
       } catch (err) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -141,7 +141,9 @@ async function seedMirrorInChunks(
   httpsUrl: string,
   branch: string
 ): Promise<void> {
-  const chunk = Number(process.env.VENFORK_SEED_CHUNK ?? 1000);
+  const rawChunk = Number(process.env.VENFORK_SEED_CHUNK ?? 1000);
+  // Guard against 0/negative (infinite loop) and NaN (chunking disabled).
+  const chunk = Number.isInteger(rawChunk) && rawChunk > 0 ? rawChunk : 1000;
 
   const revList = await $({
     cwd: tempDir,
@@ -164,7 +166,9 @@ async function seedMirrorInChunks(
         );
         return;
       } catch (err) {
-        if (attempt === attempts) throw err;
+        // A hard timeout (runNetOp -> GitError) should fail fast; only
+        // transient push failures (e.g. HTTP 408) are worth retrying.
+        if (err instanceof GitError || attempt === attempts) throw err;
         p.log.warn(
           `Push of ${label} failed; retrying in 8s ` +
             `(${attempt}/${attempts - 1})`

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -213,7 +213,10 @@ async function seedMirrorInChunks(
   const commits = revList.stdout.split('\n').filter(Boolean);
   const total = commits.length;
 
-  const backoffMs = Number(process.env.VENFORK_SEED_RETRY_MS ?? 8000);
+  const rawBackoff = Number(process.env.VENFORK_SEED_RETRY_MS ?? 8000);
+  // Fall back to the default for invalid values (negative or NaN).
+  const backoffMs =
+    Number.isFinite(rawBackoff) && rawBackoff >= 0 ? rawBackoff : 8000;
 
   const pushRef = async (src: string, label: string): Promise<void> => {
     const attempts = 4;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -269,7 +269,12 @@ async function seedMirrorInChunks(
   const commits = revList.stdout.split('\n').filter(Boolean);
   const total = commits.length;
 
-  const rawBackoff = Number(process.env.VENFORK_SEED_RETRY_MS ?? 8000);
+  // Treat unset or empty/whitespace-only env as "use default" so an empty
+  // string doesn't coerce to 0 (Number('') === 0) and silently disable
+  // backoff. An explicit '0' stays valid (0ms backoff).
+  const rawRetryMs = process.env.VENFORK_SEED_RETRY_MS;
+  const rawBackoff =
+    rawRetryMs != null && rawRetryMs.trim() !== '' ? Number(rawRetryMs) : 8000;
   // Fall back to the default for invalid values (negative or NaN).
   const backoffMs =
     Number.isFinite(rawBackoff) && rawBackoff >= 0 ? rawBackoff : 8000;

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -104,6 +104,82 @@ async function runNetOp(
   p.log.success(stopMsg);
 }
 
+/** `-c` flags that make a large seed push survive: gh credentials over
+ *  HTTPS, a big post buffer + HTTP/1.1 (avoids chunked-encoding issues on
+ *  big POSTs), and a stalled-transfer abort. */
+const SEED_PUSH_CONFIG = [
+  '-c',
+  'credential.https://github.com.helper=!gh auth git-credential',
+  '-c',
+  'http.postBuffer=524288000',
+  '-c',
+  'http.version=HTTP/1.1',
+  '-c',
+  'http.lowSpeedLimit=1000',
+  '-c',
+  'http.lowSpeedTime=60',
+];
+
+/**
+ * Seed a fresh private mirror from a local upstream clone.
+ *
+ * A single `git push` of a large repo's full history 408s — GitHub enforces
+ * a request-duration limit and the monolithic pack POST exceeds it. So push
+ * the default branch in commit batches (each POST stays small), then push the
+ * real tip. History/SHAs are identical to upstream, which `sync`/`stage`/PRs
+ * require. Each push is retried a few times to ride out transient 408s.
+ *
+ * Batch size is `VENFORK_SEED_CHUNK` commits (default 1000); small repos take
+ * a single push (loop body is skipped).
+ *
+ * @param tempDir Local upstream clone.
+ * @param httpsUrl HTTPS URL of the private mirror.
+ * @param branch Default branch to seed.
+ */
+async function seedMirrorInChunks(
+  tempDir: string,
+  httpsUrl: string,
+  branch: string
+): Promise<void> {
+  const chunk = Number(process.env.VENFORK_SEED_CHUNK ?? 1000);
+
+  const revList = await $({
+    cwd: tempDir,
+  })`git rev-list --reverse ${branch}`;
+  const commits = revList.stdout.split('\n').filter(Boolean);
+  const total = commits.length;
+
+  const pushRef = async (src: string, label: string): Promise<void> => {
+    const attempts = 4;
+    for (let attempt = 1; attempt <= attempts; attempt++) {
+      try {
+        await runNetOp(
+          `Pushing ${label} to private mirror repository` +
+            (attempt > 1 ? ` (attempt ${attempt})` : ''),
+          `Pushed ${label}`,
+          () =>
+            netExec(
+              tempDir
+            )`git ${SEED_PUSH_CONFIG} push --force --no-thin --progress ${httpsUrl} ${src}:refs/heads/${branch}`
+        );
+        return;
+      } catch (err) {
+        if (attempt === attempts) throw err;
+        p.log.warn(
+          `Push of ${label} failed; retrying in 8s ` +
+            `(${attempt}/${attempts - 1})`
+        );
+        await new Promise((resolve) => setTimeout(resolve, 8000));
+      }
+    }
+  };
+
+  for (let i = chunk; i < total; i += chunk) {
+    await pushRef(commits[i - 1], `commits 1–${i}/${total}`);
+  }
+  await pushRef(branch, `${branch} (final)`);
+}
+
 /**
  * `p.confirm` wrapper that can return `true` immediately when
  * `VENFORK_NONINTERACTIVE=1` is set in the environment, but only for
@@ -1027,15 +1103,7 @@ export async function setupCommand(
       }
       s.stop(`Default branch: ${defaultBranch}`);
 
-      const ghCredentialHelper = '!gh auth git-credential';
-      await runNetOp(
-        `Pushing ${defaultBranch} to private mirror repository`,
-        'Pushed to private mirror repository',
-        () =>
-          netExec(
-            tempDir
-          )`git -c credential.https://github.com.helper=${ghCredentialHelper} -c http.lowSpeedLimit=1000 -c http.lowSpeedTime=60 push --progress ${privateHttpsUrl} ${defaultBranch}:${defaultBranch}`
-      );
+      await seedMirrorInChunks(tempDir, privateHttpsUrl, defaultBranch);
     }
 
     // Step 6: Local clone of the private mirror

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -121,6 +121,67 @@ const SEED_PUSH_CONFIG = [
 ];
 
 /**
+ * Whether a failed seed push is worth retrying. Retry only recognized
+ * server-side/transport failures during a large transfer (timeouts,
+ * gateways, dropped connections). Auth/permission/not-found/protected-branch
+ * and any unrecognized failure fail fast — retrying those just delays a
+ * permanent setup error.
+ */
+function isTransientPushError(err: unknown): boolean {
+  if (err instanceof GitError) return false; // hard timeout
+  const e = err as {
+    stderr?: unknown;
+    stdout?: unknown;
+    shortMessage?: unknown;
+    message?: unknown;
+  };
+  const text = [e.stderr, e.stdout, e.shortMessage, e.message]
+    .map((v) => (typeof v === 'string' ? v : ''))
+    .join('\n')
+    .toLowerCase();
+  if (!text) return false;
+
+  const permanent = [
+    'http 401',
+    'http 403',
+    'http 404',
+    'authentication failed',
+    'permission denied',
+    'access denied',
+    'repository not found',
+    'could not read from remote repository',
+    'protected branch',
+    'pre-receive hook declined',
+    'remote rejected',
+    'remote: error: gh',
+  ];
+  if (permanent.some((p) => text.includes(p))) return false;
+
+  const transient = [
+    'http 408',
+    'error: 408',
+    'http 500',
+    'http 502',
+    'http 503',
+    'http 504',
+    'bad gateway',
+    'gateway time',
+    'service unavailable',
+    'the remote end hung up',
+    'unexpected disconnect',
+    'rpc failed',
+    'early eof',
+    'connection reset',
+    'connection timed out',
+    'operation timed out',
+    'failed to connect',
+    'recv failure',
+    'transfer closed',
+  ];
+  return transient.some((p) => text.includes(p));
+}
+
+/**
  * Seed a fresh private mirror from a local upstream clone.
  *
  * A single `git push` of a large repo's full history 408s — GitHub enforces
@@ -142,7 +203,8 @@ async function seedMirrorInChunks(
   branch: string
 ): Promise<void> {
   const rawChunk = Number(process.env.VENFORK_SEED_CHUNK ?? 1000);
-  // Guard against 0/negative (infinite loop) and NaN (chunking disabled).
+  // Fall back to the default chunk size for invalid values: 0/negative
+  // (would infinite-loop) or NaN (non-numeric env).
   const chunk = Number.isInteger(rawChunk) && rawChunk > 0 ? rawChunk : 1000;
 
   const revList = await $({
@@ -150,6 +212,8 @@ async function seedMirrorInChunks(
   })`git rev-list --reverse ${branch}`;
   const commits = revList.stdout.split('\n').filter(Boolean);
   const total = commits.length;
+
+  const backoffMs = Number(process.env.VENFORK_SEED_RETRY_MS ?? 8000);
 
   const pushRef = async (src: string, label: string): Promise<void> => {
     const attempts = 4;
@@ -166,14 +230,14 @@ async function seedMirrorInChunks(
         );
         return;
       } catch (err) {
-        // A hard timeout (runNetOp -> GitError) should fail fast; only
-        // transient push failures (e.g. HTTP 408) are worth retrying.
-        if (err instanceof GitError || attempt === attempts) throw err;
+        // Fail fast on the last attempt, hard timeouts, and permanent
+        // errors (bad creds, missing access, protected branch, …); only
+        // recognized transient failures (e.g. HTTP 408) are retried.
+        if (attempt === attempts || !isTransientPushError(err)) throw err;
         p.log.warn(
-          `Push of ${label} failed; retrying in 8s ` +
-            `(${attempt}/${attempts - 1})`
+          `Push of ${label} failed; retrying ` + `(${attempt}/${attempts - 1})`
         );
-        await new Promise((resolve) => setTimeout(resolve, 8000));
+        await new Promise((resolve) => setTimeout(resolve, backoffMs));
       }
     }
   };

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -184,12 +184,12 @@ function isTransientPushError(err: unknown): boolean {
   return transient.some((p) => text.includes(p));
 }
 
-const PUSH_ERROR_TAIL_CHARS = 16_384;
+const PUSH_OUTPUT_TAIL_CHARS = 16_384;
 
 function appendTail(text: string, chunk: string): string {
   const next = text + chunk;
-  return next.length > PUSH_ERROR_TAIL_CHARS
-    ? next.slice(-PUSH_ERROR_TAIL_CHARS)
+  return next.length > PUSH_OUTPUT_TAIL_CHARS
+    ? next.slice(-PUSH_OUTPUT_TAIL_CHARS)
     : next;
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -261,9 +261,11 @@ async function seedMirrorInChunks(
   // (would infinite-loop) or NaN (non-numeric env).
   const chunk = Number.isInteger(rawChunk) && rawChunk > 0 ? rawChunk : 1000;
 
+  // Select chunk tips along the branch's first-parent ancestry so each pushed
+  // tip is guaranteed to descend from the previous one.
   const revList = await $({
     cwd: tempDir,
-  })`git rev-list --reverse ${branch}`;
+  })`git rev-list --first-parent --reverse ${branch}`;
   const commits = revList.stdout.split('\n').filter(Boolean);
   const total = commits.length;
 

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { PassThrough } from 'node:stream';
 
 /**
  * Command tests with execution-based mocking
@@ -17,7 +18,7 @@ interface WriteFileCall {
 type SignalHandler = () => void | Promise<void>;
 type MockResponse =
   | { exitCode: number; stdout: string; stderr: string }
-  | ((command: string) => Promise<unknown>);
+  | ((command: string) => unknown);
 
 // Track calls to our mocks
 const execaCalls: string[] = [];
@@ -148,6 +149,22 @@ function getMockExecaResponse(command: string) {
 
   // Default response for all other commands
   return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+}
+
+function streamRejectedPush(stderr: string): Promise<unknown> & {
+  stdout: PassThrough;
+  stderr: PassThrough;
+} {
+  const stdout = new PassThrough();
+  const stderrStream = new PassThrough();
+  const promise = new Promise<unknown>((_resolve, reject) => {
+    queueMicrotask(() => {
+      stderrStream.write(stderr);
+      stderrStream.end();
+      reject(Object.assign(new Error('Command failed'), { exitCode: 128 }));
+    });
+  });
+  return Object.assign(promise, { stdout, stderr: stderrStream });
 }
 
 // Mock fs.rm and fs.access BEFORE any imports
@@ -425,7 +442,7 @@ describe('setupCommand - execution tests', () => {
 
   test('seeds large history in commit-batched pushes, then the real tip', async () => {
     process.env.VENFORK_SEED_CHUNK = '2';
-    mockResponses.set('git rev-list --reverse main', {
+    mockResponses.set('git rev-list --first-parent --reverse main', {
       exitCode: 0,
       stdout: 'aaa\nbbb\nccc\nddd\neee',
       stderr: '',
@@ -458,11 +475,16 @@ describe('setupCommand - execution tests', () => {
       true
     );
     expect(seedPushes.every((c) => c.includes('--force'))).toBe(true);
+    expect(
+      execaCalls.some((c) =>
+        c.includes('git rev-list --first-parent --reverse main')
+      )
+    ).toBe(true);
   });
 
   test('invalid VENFORK_SEED_CHUNK falls back to default (no infinite loop)', async () => {
     process.env.VENFORK_SEED_CHUNK = '0';
-    mockResponses.set('git rev-list --reverse main', {
+    mockResponses.set('git rev-list --first-parent --reverse main', {
       exitCode: 0,
       stdout: 'aaa\nbbb\nccc\nddd\neee',
       stderr: '',
@@ -537,6 +559,30 @@ describe('setupCommand - execution tests', () => {
         cmd.includes('https://github.com/testuser/test-vendor.git')
     );
     expect(seedPushes.length).toBe(4); // 1 + 3 retries
+  });
+
+  test('retries transient seed-push failures from streamed stderr when error has no buffered output', async () => {
+    process.env.VENFORK_SEED_RETRY_MS = '0';
+    mockResponses.set('push --force --no-thin', () =>
+      streamRejectedPush(
+        'error: RPC failed; HTTP 408 curl 22\n' +
+          'fatal: the remote end hung up unexpectedly'
+      )
+    );
+    try {
+      await setupCommand('git@github.com:test/repo.git', 'test-vendor');
+    } catch {
+      // Expected
+    } finally {
+      delete process.env.VENFORK_SEED_RETRY_MS;
+    }
+
+    const seedPushes = execaCalls.filter(
+      (cmd) =>
+        cmd.includes('push --force --no-thin') &&
+        cmd.includes('https://github.com/testuser/test-vendor.git')
+    );
+    expect(seedPushes.length).toBe(4); // 1 + 3 retries from streamed stderr tail
   });
 
   test('does not retry generic rpc-failed wrappers without transient status', async () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -162,13 +162,12 @@ function streamRejectedPush(stderr: string): Promise<unknown> & {
 } {
   const stdout = new PassThrough();
   const stderrStream = new PassThrough();
-  const promise = new Promise<unknown>((_resolve, reject) => {
-    queueMicrotask(() => {
-      stderrStream.write(stderr);
-      stderrStream.end();
-      reject(Object.assign(new Error('Command failed'), { exitCode: 128 }));
-    });
-  });
+  const promise = (async (): Promise<unknown> => {
+    await Promise.resolve();
+    stderrStream.write(stderr);
+    stderrStream.end();
+    throw Object.assign(new Error('Command failed'), { exitCode: 128 });
+  })();
   return Object.assign(promise, { stdout, stderr: stderrStream });
 }
 
@@ -563,7 +562,7 @@ describe('setupCommand - execution tests', () => {
         cmd.includes('push --force --no-thin') &&
         cmd.includes('https://github.com/testuser/test-vendor.git')
     );
-    expect(seedPushes.length).toBe(4); // 1 + 3 retries
+    expect(seedPushes.length).toBe(4); // 1 + 3 retries from transient stderr
   });
 
   test('retries transient seed-push failures from streamed stderr when error has no buffered output', async () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -539,6 +539,29 @@ describe('setupCommand - execution tests', () => {
     expect(seedPushes.length).toBe(4); // 1 + 3 retries
   });
 
+  test('does not retry generic rpc-failed wrappers without transient status', async () => {
+    mockResponses.set('push --force --no-thin', () =>
+      Promise.reject(
+        Object.assign(new Error('Command failed'), {
+          stderr: 'error: RPC failed; HTTP 413 curl 22',
+          exitCode: 128,
+        })
+      )
+    );
+    try {
+      await setupCommand('git@github.com:test/repo.git', 'test-vendor');
+    } catch {
+      // Expected
+    }
+
+    const seedPushes = execaCalls.filter(
+      (cmd) =>
+        cmd.includes('push --force --no-thin') &&
+        cmd.includes('https://github.com/testuser/test-vendor.git')
+    );
+    expect(seedPushes.length).toBe(1); // no retries for unrecognized wrappers
+  });
+
   test('passes --progress to upstream and private mirror clones', async () => {
     try {
       await setupCommand('git@github.com:test/repo.git', 'test-vendor');

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -418,9 +418,46 @@ describe('setupCommand - execution tests', () => {
     expect(seedPush).toBeDefined();
     expect(seedPush).toContain('credential.https://github.com.helper');
     expect(seedPush).toContain('--progress');
-    expect(seedPush).toContain('main:main');
+    expect(seedPush).toContain('main:refs/heads/main');
     // The hang fix: the seeding push must not use the raw SSH URL.
     expect(seedPush).not.toContain('git@github.com:');
+  });
+
+  test('seeds large history in commit-batched pushes, then the real tip', async () => {
+    process.env.VENFORK_SEED_CHUNK = '2';
+    mockResponses.set('git rev-list --reverse main', {
+      exitCode: 0,
+      stdout: 'aaa\nbbb\nccc\nddd\neee',
+      stderr: '',
+    });
+    try {
+      await setupCommand('git@github.com:test/repo.git', 'test-vendor');
+    } catch {
+      // Expected
+    } finally {
+      delete process.env.VENFORK_SEED_CHUNK;
+    }
+
+    const seedPushes = execaCalls.filter(
+      (cmd) =>
+        cmd.includes(' push ') &&
+        cmd.includes('https://github.com/testuser/test-vendor.git') &&
+        cmd.includes(':refs/heads/main')
+    );
+
+    // 5 commits, chunk 2 -> push at commit 2 (bbb), commit 4 (ddd),
+    // then the real branch tip.
+    expect(seedPushes.length).toBe(3);
+    expect(seedPushes.some((c) => c.includes('bbb:refs/heads/main'))).toBe(
+      true
+    );
+    expect(seedPushes.some((c) => c.includes('ddd:refs/heads/main'))).toBe(
+      true
+    );
+    expect(seedPushes.some((c) => c.includes('main:refs/heads/main'))).toBe(
+      true
+    );
+    expect(seedPushes.every((c) => c.includes('--force'))).toBe(true);
   });
 
   test('passes --progress to upstream and private mirror clones', async () => {

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -486,6 +486,59 @@ describe('setupCommand - execution tests', () => {
     expect(seedPushes[0]).toContain('main:refs/heads/main');
   });
 
+  test('does not retry permanent seed-push failures (fails fast)', async () => {
+    mockResponses.set('push --force --no-thin', () =>
+      Promise.reject(
+        Object.assign(new Error('Command failed'), {
+          stderr:
+            'remote: Permission to testuser/test-vendor.git denied.\n' +
+            'fatal: unable to access: The requested URL returned error: HTTP 403',
+          exitCode: 128,
+        })
+      )
+    );
+    try {
+      await setupCommand('git@github.com:test/repo.git', 'test-vendor');
+    } catch {
+      // Expected
+    }
+
+    const seedPushes = execaCalls.filter(
+      (cmd) =>
+        cmd.includes('push --force --no-thin') &&
+        cmd.includes('https://github.com/testuser/test-vendor.git')
+    );
+    expect(seedPushes.length).toBe(1); // no retries for a permanent error
+  });
+
+  test('retries transient seed-push failures up to the attempt limit', async () => {
+    process.env.VENFORK_SEED_RETRY_MS = '0';
+    mockResponses.set('push --force --no-thin', () =>
+      Promise.reject(
+        Object.assign(new Error('Command failed'), {
+          stderr:
+            'error: RPC failed; HTTP 408 curl 22\n' +
+            'fatal: the remote end hung up unexpectedly',
+          exitCode: 128,
+        })
+      )
+    );
+    try {
+      await setupCommand('git@github.com:test/repo.git', 'test-vendor');
+    } catch {
+      // Expected
+    } finally {
+      delete process.env.VENFORK_SEED_RETRY_MS;
+    }
+
+    const seedPushes = execaCalls.filter(
+      (cmd) =>
+        cmd.includes('push --force --no-thin') &&
+        cmd.includes('https://github.com/testuser/test-vendor.git')
+    );
+    expect(seedPushes.length).toBe(4); // 1 + 3 retries
+  });
+
   test('passes --progress to upstream and private mirror clones', async () => {
     try {
       await setupCommand('git@github.com:test/repo.git', 'test-vendor');

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -460,6 +460,32 @@ describe('setupCommand - execution tests', () => {
     expect(seedPushes.every((c) => c.includes('--force'))).toBe(true);
   });
 
+  test('invalid VENFORK_SEED_CHUNK falls back to default (no infinite loop)', async () => {
+    process.env.VENFORK_SEED_CHUNK = '0';
+    mockResponses.set('git rev-list --reverse main', {
+      exitCode: 0,
+      stdout: 'aaa\nbbb\nccc\nddd\neee',
+      stderr: '',
+    });
+    try {
+      await setupCommand('git@github.com:test/repo.git', 'test-vendor');
+    } catch {
+      // Expected
+    } finally {
+      delete process.env.VENFORK_SEED_CHUNK;
+    }
+
+    // chunk=0 -> guarded to 1000 -> 5 commits skip the loop -> single tip push.
+    const seedPushes = execaCalls.filter(
+      (cmd) =>
+        cmd.includes(' push ') &&
+        cmd.includes('https://github.com/testuser/test-vendor.git') &&
+        cmd.includes(':refs/heads/main')
+    );
+    expect(seedPushes.length).toBe(1);
+    expect(seedPushes[0]).toContain('main:refs/heads/main');
+  });
+
   test('passes --progress to upstream and private mirror clones', async () => {
     try {
       await setupCommand('git@github.com:test/repo.git', 'test-vendor');

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -18,7 +18,7 @@ interface WriteFileCall {
 type SignalHandler = () => void | Promise<void>;
 type MockResponse =
   | { exitCode: number; stdout: string; stderr: string }
-  | ((command: string) => unknown);
+  | ((command: string) => Promise<unknown>);
 
 // Track calls to our mocks
 const execaCalls: string[] = [];
@@ -151,6 +151,11 @@ function getMockExecaResponse(command: string) {
   return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
 }
 
+/**
+ * Simulate execa with `buffer: false`: push fails with no buffered
+ * stdout/stderr on the error object, while stderr is only available via the
+ * live stream attached to the returned promise.
+ */
 function streamRejectedPush(stderr: string): Promise<unknown> & {
   stdout: PassThrough;
   stderr: PassThrough;

--- a/tests/commands.test.ts
+++ b/tests/commands.test.ts
@@ -162,8 +162,9 @@ function streamRejectedPush(stderr: string): Promise<unknown> & {
 } {
   const stdout = new PassThrough();
   const stderrStream = new PassThrough();
+  stdout.end();
   const promise = (async (): Promise<unknown> => {
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     stderrStream.write(stderr);
     stderrStream.end();
     throw Object.assign(new Error('Command failed'), { exitCode: 128 });


### PR DESCRIPTION
Closes #44

## Problem

`venfork setup` seeds a new private mirror with a single `git push <default>:<default>` of full upstream history. For large upstreams GitHub 408s — it enforces an HTTP request-duration limit and the monolithic pack POST exceeds it:

```
error: RPC failed; HTTP 408 curl 22 The requested URL returned error: 408
send-pack: unexpected disconnect while reading sideband packet
fatal: the remote end hung up unexpectedly
```

Reproduced seeding `genkit-ai/genkit` (~203 MB pack) into a private mirror over gh-authenticated HTTPS (0.9.0, with the SSH-hang fix from #43). Distinct from the auth hang and not a rate limit — a request-duration timeout.

The Source Imports REST API (which could offload this server-side) was [deprecated and returns an error since 2024-04-12](https://github.blog/changelog/2024-04-17-updates-to-github-importer-and-the-deprecation-of-the-source-import-rest-api-endpoint/), so venfork must transfer the pack itself.

## Change

New `seedMirrorInChunks(tempDir, httpsUrl, branch)`:

- `git rev-list --reverse <branch>` → push in batches of `VENFORK_SEED_CHUNK` commits (default 1000), `--force --no-thin`, each to `refs/heads/<branch>`; then push the real tip.
- Each POST stays under GitHub's timeout. Full history / identical SHAs to upstream preserved — required for `sync`/`stage`/`--pr`.
- Per-push retry (4 attempts, 8s backoff) to ride out transient 408s.
- Small repos (`commits <= chunk`) take a single push — no regression.
- Pushes carry `http.postBuffer=512MB` + `http.version=HTTP/1.1` + low-speed abort, alongside the existing gh credential helper and `netExec` timeout / non-interactive env.

Replaces the single seed push in the `setup` flow.

## Validated

This exact strategy was used manually to successfully seed `invertase/genkit-typescript-sandbox` from genkit (5063 commits, 5 chunks + tip) after the single push 408'd.

## Tests

- `bunx tsc --noEmit` clean, `bun run check` clean, `bun test` → 289 pass / 0 fail.
- Updated the HTTPS-seed test for the new `:refs/heads/main` refspec.
- New test: 5 commits + `VENFORK_SEED_CHUNK=2` → exactly 3 force pushes (commit 2, commit 4, real tip).